### PR TITLE
feat(prediction-market): HF14 prediction market operations & API support

### DIFF
--- a/.qoder/docs/operations-status.md
+++ b/.qoder/docs/operations-status.md
@@ -1,7 +1,7 @@
 # VIZ PHP Library — Operations Implementation Status
 
-**Status Date:** 16.05.2026
-**Reference:** viz-cpp-node documentation
+**Status Date:** 02.07.2026
+**Reference:** viz-cpp-node documentation + prediction-market-library-integration-spec (HF14, Onix)
 
 ---
 
@@ -235,8 +235,8 @@ $tx->execute($result['json']);
 
 # JSON-RPC API Coverage
 
-**Status Date:** 16.05.2026
-**Reference:** viz-cpp-node plugins documentation
+**Status Date:** 02.07.2026
+**Reference:** viz-cpp-node plugins documentation + prediction_market_api (HF14, Onix)
 
 ---
 
@@ -257,12 +257,13 @@ $tx->execute($result['json']);
 | block_info | 2 | 2 | ✅ Complete |
 | raw_block | 1 | 1 | ✅ Complete |
 | auth_util | 1 | 1 | ✅ Complete |
+| prediction_market_api (HF14) | 29 | 29 | ✅ Complete |
 | follow | 9 | 0 | ⚠️ Deprecated |
 | tags | 15 | 0 | ⚠️ Deprecated |
 | social_network | 12 | 0 | ⚠️ Deprecated |
 | private_message | 2 | 0 | ⚠️ Deprecated |
 | debug_node | 8 | 0 | 🔧 Dev only |
-| **TOTAL (non-deprecated)** | **79** | **79** | **100%** |
+| **TOTAL (non-deprecated)** | **108** | **108** | **100%** |
 
 ---
 
@@ -408,6 +409,49 @@ All validator and witness method names route to the `validator_api` plugin on ne
 | Method | Status |
 |--------|--------|
 | `check_authority_signature` | ✅ Added 03.03.2026 |
+
+---
+
+### prediction_market_api (29 methods) ✅
+
+All PM read methods route to the `prediction_market_api` plugin. Pagination is uniformly
+`(…key…, from, limit)` with `limit ≤ 1000`. Call via `execute_method('<method>', [args])`.
+
+| Method | Status | Returns |
+|--------|--------|---------|
+| `get_market` | ✅ Added 02.07.2026 | `pm_market_object` |
+| `list_markets` | ✅ Added 02.07.2026 | `pm_market_object[]` (`status, from, limit, [show_risky]`) |
+| `list_markets_by_oracle` | ✅ Added 02.07.2026 | `pm_market_object[]` |
+| `list_markets_by_creator` | ✅ Added 02.07.2026 | `pm_market_object[]` |
+| `get_market_outcomes` | ✅ Added 02.07.2026 | `pm_outcome_object[]` |
+| `get_market_weight_sums` | ✅ Added 02.07.2026 | `pm_market_weight_sums_api_object` |
+| `get_market_bets` | ✅ Added 02.07.2026 | `pm_bet_object[]` |
+| `get_account_positions` | ✅ Added 02.07.2026 | `pm_position_api_object[]` |
+| `get_market_liquidity` | ✅ Added 02.07.2026 | `pm_liquidity_object[]` |
+| `get_market_full` | ✅ Added 02.07.2026 | `pm_market_full_api_object` (`market_id, [account]`) |
+| `get_account_leverage_positions` | ✅ Added 02.07.2026 | `pm_leverage_position_object[]` |
+| `get_market_leverage_positions` | ✅ Added 02.07.2026 | `pm_leverage_position_object[]` |
+| `get_creator_ban` | ✅ Added 02.07.2026 | `pm_creator_ban_object` |
+| `get_leverage_quote` | ✅ Added 02.07.2026 | `pm_leverage_quote_api_object` |
+| `get_leverage_close_preview` | ✅ Added 02.07.2026 | `pm_leverage_close_preview_api_object` |
+| `get_leverage_convert_preview` | ✅ Added 02.07.2026 | `pm_leverage_convert_preview_api_object` |
+| `get_oracle` | ✅ Added 02.07.2026 | `pm_oracle_api_object` |
+| `list_oracles` | ✅ Added 02.07.2026 | `pm_oracle_object[]` |
+| `get_dispute` | ✅ Added 02.07.2026 | `pm_dispute_object` |
+| `get_dispute_votes` | ✅ Added 02.07.2026 | `pm_dispute_votes_api_object` |
+| `get_lazy_pool` | ✅ Added 02.07.2026 | `pm_lazy_pool_object` (no args) |
+| `get_lazy_deposit` | ✅ Added 02.07.2026 | `pm_lazy_deposit_object` |
+| `get_lazy_allocations` | ✅ Added 02.07.2026 | `pm_lazy_allocation_object[]` |
+| `get_market_lazy_allocation` | ✅ Added 02.07.2026 | `pm_lazy_allocation_object` |
+| `get_pm_chain_properties` | ✅ Added 02.07.2026 | `chain_properties_pm` (median governance params, no args) |
+| `get_market_meta` | ✅ Added 02.07.2026 | `pm_market_meta_object` |
+| `list_markets_by_category` | ✅ Added 02.07.2026 | `pm_market_meta_object[]` |
+| `get_market_categories` | ✅ Added 02.07.2026 | `pm_market_categories_api_object` (no args) |
+| `get_market_kline` | ✅ Added 02.07.2026 | `pm_kline_api_object[]` (offset-from-newest paging) |
+
+> Requires the node to run the `prediction_market_api` plugin (needs `chain` + `json_rpc`).
+> The three leverage preview methods are **non-consensus quotes** — always send on-chain slippage
+> guards (`min_tokens` / `min_return` / `conversion_profit_cost`) when broadcasting.
 
 ---
 

--- a/.qoder/docs/operations-status.md
+++ b/.qoder/docs/operations-status.md
@@ -21,9 +21,13 @@
 | Subscription Operations | 2 | 2 | 0 | 0 |
 | Transfer & Vesting Operations | 5 | 5 | 0 | 0 |
 | Witness / Validator Operations | 6 | 6 | 0 | 0 |
-| **TOTAL** | **43** | **40** | **0** | **3** |
+| Prediction Market Operations (HF14) | 23 | 23 | 0 | 0 |
+| **TOTAL** | **66** | **63** | **0** | **3** |
 
 **Coverage:** 100% of non-deprecated operations implemented
+
+> Virtual operations (chain-generated, decode-only — never built/signed) are not counted above.
+> See [Virtual Operations](#virtual-operations-decode-only) for the HF14 PM vops and `stakeholder_reward`.
 
 ---
 
@@ -89,6 +93,60 @@
 | 25 | `chain_properties_update_operation` | `build_chain_properties_update()` | ✅ Implemented | Added 03.03.2026 |
 | 46 | `versioned_chain_properties_update_operation` | `build_versioned_chain_properties_update()` | ✅ Implemented | Updated to v4 (HF13) |
 | 64 | `set_reward_sharing_operation` | `build_set_reward_sharing()` | ✅ Implemented | HF13 |
+| **Prediction Market Operations (HF14, Onix)** |||||
+| 66 | `pm_oracle_register_operation` | `build_pm_oracle_register()` | ✅ Implemented | active(owner) |
+| 67 | `pm_oracle_update_operation` | `build_pm_oracle_update()` | ✅ Implemented | active(owner); optional fields = `null` |
+| 68 | `pm_create_market_operation` | `build_pm_create_market()` | ✅ Implemented | active(creator) |
+| 69 | `pm_oracle_accept_market_operation` | `build_pm_oracle_accept_market()` | ✅ Implemented | active(oracle) |
+| 70 | `pm_place_bet_operation` | `build_pm_place_bet()` | ✅ Implemented | active(account) |
+| 71 | `pm_commit_bet_operation` | `build_pm_commit_bet()` | ✅ Implemented | active(account); see `pm_commitment()` |
+| 72 | `pm_reveal_bet_operation` | `build_pm_reveal_bet()` | ✅ Implemented | active(account) |
+| 73 | `pm_cancel_bet_operation` | `build_pm_cancel_bet()` | ✅ Implemented | active(account) |
+| 74 | `pm_add_liquidity_operation` | `build_pm_add_liquidity()` | ✅ Implemented | active(provider) |
+| 75 | `pm_withdraw_liquidity_operation` | `build_pm_withdraw_liquidity()` | ✅ Implemented | active(provider) |
+| 76 | `pm_resolve_market_operation` | `build_pm_resolve_market()` | ✅ Implemented | active(oracle) |
+| 77 | `pm_no_contest_operation` | `build_pm_no_contest()` | ✅ Implemented | active(oracle) |
+| 78 | `pm_dispute_create_operation` | `build_pm_dispute_create()` | ✅ Implemented | active(disputer) |
+| 79 | `pm_dispute_vote_operation` | `build_pm_dispute_vote()` | ✅ Implemented | **regular**(voter) |
+| 80 | `pm_dispute_resolve_operation` | `build_pm_dispute_resolve()` | ✅ Implemented | active(resolver) |
+| 81 | `pm_transfer_position_operation` | `build_pm_transfer_position()` | ✅ Implemented | active(from) |
+| 82 | `pm_lazy_deposit_operation` | `build_pm_lazy_deposit()` | ✅ Implemented | active(account) |
+| 83 | `pm_lazy_withdraw_operation` | `build_pm_lazy_withdraw()` | ✅ Implemented | active(account) |
+| 91 | `pm_leverage_open_operation` | `build_pm_leverage_open()` | ✅ Implemented | active(account); gated by `pm_leverage_enabled` |
+| 92 | `pm_leverage_close_operation` | `build_pm_leverage_close()` | ✅ Implemented | active(account) |
+| 93 | `pm_leverage_convert_operation` | `build_pm_leverage_convert()` | ✅ Implemented | active(account) |
+| 98 | `pm_dispute_oracle_respond_operation` | `build_pm_dispute_oracle_respond()` | ✅ Implemented | active(oracle) |
+| 99 | `pm_unban_operation` | `build_pm_unban()` | ✅ Implemented | active(resolver) |
+
+> PM op-ids are **not contiguous** — 84–90, 94–97 and 100 are virtual ops interleaved in the
+> `operation` variant (see below). Every PM user op ends with an empty `extensions` vector and is
+> serialized by JSON name (`["pm_place_bet", {...}]`); percent fields are basis points unless noted.
+
+---
+
+## Virtual Operations (decode-only)
+
+Virtual operations are emitted by the node (block/account history) and **cannot be built or signed** —
+the library only decodes them from `get_account_history` / `get_ops_in_block` (returned already-named
+in JSON, no builder or decoder registry needed).
+
+| ID | Operation Name | Emitted when |
+|----|----------------|--------------|
+| 65 | `stakeholder_reward` | HF13 epoch payout: validator with non-zero `sharing_rate` pays a voter their `shares` (SHARES asset, precision 6) |
+| 84 | `pm_batch_settle` | Epoch boundary: queued/revealed bets settle at a uniform price |
+| 85 | `pm_commit_forfeit` | An unrevealed commitment forfeits its penalty into `forfeit_pool` |
+| 86 | `pm_auto_payout` | Deferred market-level payout marker after the dispute grace elapses |
+| 87 | `pm_dispute_finalize` | Committee-mode tally finalized at `voting_end_time` |
+| 88 | `pm_dispute_auto_close` | Anti-freeze: dispute unresolved at `auto_close_time` → full refund |
+| 89 | `pm_oracle_missed_penalty` | Oracle missed `result_expiration` → insurance slashed, refund all |
+| 90 | `pm_lazy_recall` | Lazy-pool graduated recall step (idle allocation returned) |
+| 94 | `pm_leverage_liquidate` | A leveraged position force-closed (opposing bet / cancel / expiration) |
+| 95 | `pm_leverage_resolve` | A leveraged position settled at market resolution |
+| 96 | `pm_market_accepted` | Oracle accepted (or self-oracle auto-accepted); terms frozen |
+| 97 | `pm_payout` | Per-bettor parimutuel settlement (one per active bet inside settle) |
+| 100 | `pm_ban_expired` | A temporary oracle/creator ban lapsed at `banned_until`; cron cleared it |
+
+> Also chain-generated (pre-HF14): `shutdown_validator` (30), `validator_reward` (42).
 
 ---
 
@@ -101,6 +159,16 @@
 | ❌ | Missing (needs implementation) |
 
 ---
+
+## Recently Added (02.07.2026)
+
+- **Prediction Markets (HF14, Onix)** — all 23 signed PM operations (IDs 66–83, 91–93, 98–99):
+  `build_pm_oracle_register()` … `build_pm_unban()`. See the PM section of the detailed table.
+- `pm_commitment()` helper — builds the byte-exact SHA-256 commit-reveal commitment (spec §3.6.1),
+  verified against the spec golden test vector.
+- New binary codecs on `Transaction`: `encode_int8`, `encode_int64` (LE), `encode_sha256`,
+  `encode_optional` (fc `optional<T>`), `json_string`.
+- 12 PM virtual ops + `stakeholder_reward` (ID 65) documented as decode-only.
 
 ## Recently Added (16.05.2026)
 

--- a/.qoder/docs/spec/jsonrpc-api-spec.json
+++ b/.qoder/docs/spec/jsonrpc-api-spec.json
@@ -1,0 +1,1353 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VIZ Blockchain JSON-RPC API Specification",
+  "description": "Complete specification of all JSON-RPC methods exposed by VIZ node plugins. Intended as a machine-readable spec for API explorer generation.",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "validator_api",
+      "description": "Provides read-only access to validator (witness) data: schedules, votes, and validator registration info.",
+      "methods": [
+        {
+          "method": "get_active_validators",
+          "description": "Returns the list of currently active validator account names that are participating in block production.",
+          "aliases": ["get_active_witnesses"],
+          "params": [],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Array of account names of currently active validators."
+          }
+        },
+        {
+          "method": "get_validator_schedule",
+          "description": "Returns the current validator schedule object, including the shuffled list of validators and their timeshares.",
+          "aliases": ["get_witness_schedule"],
+          "params": [],
+          "returns": {
+            "type": "object",
+            "description": "The validator_schedule_object containing current_shuffled_validators, timeshare, and related scheduling data."
+          }
+        },
+        {
+          "method": "get_validators",
+          "description": "Returns a list of validator objects by their database IDs. For each ID, returns either the validator_api_object or null if not found.",
+          "aliases": ["get_witnesses"],
+          "params": [
+            {
+              "name": "validator_ids",
+              "caption": "Validator IDs",
+              "description": "Array of validator object database IDs to look up.",
+              "type": "array",
+              "items": { "type": "integer" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of optional validator_api_object entries, one per requested ID."
+          }
+        },
+        {
+          "method": "get_validator_by_account",
+          "description": "Returns the validator object registered under a specific account name, or null if the account is not a validator.",
+          "aliases": ["get_witness_by_account"],
+          "params": [
+            {
+              "name": "account_name",
+              "caption": "Account Name",
+              "description": "The account name to look up as a validator.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The validator_api_object for the account, or null if not a validator.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "get_validators_by_vote",
+          "description": "Returns validators sorted by total votes (descending). Starts from a given account name. Only returns validators with votes > 0. Maximum 100 results.",
+          "aliases": ["get_witnesses_by_vote"],
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Account",
+              "description": "The account name to start from. Use empty string to start from the top.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 100.",
+              "type": "integer",
+              "required": true,
+              "maximum": 100
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of validator_api_object entries sorted by vote count."
+          }
+        },
+        {
+          "method": "get_validators_by_counted_vote",
+          "description": "Returns validators sorted by counted votes (descending). Starts from a given account name. Only returns validators with counted_votes > 0. Maximum 100 results.",
+          "aliases": ["get_witnesses_by_counted_vote"],
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Account",
+              "description": "The account name to start from. Use empty string to start from the top.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 100.",
+              "type": "integer",
+              "required": true,
+              "maximum": 100
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of validator_api_object entries sorted by counted vote."
+          }
+        },
+        {
+          "method": "get_validator_count",
+          "description": "Returns the total number of registered validators on the blockchain.",
+          "aliases": ["get_witness_count"],
+          "params": [],
+          "returns": {
+            "type": "integer",
+            "description": "Total count of registered validators."
+          }
+        },
+        {
+          "method": "lookup_validator_accounts",
+          "description": "Looks up validator account names starting from a lower bound. Returns up to 1000 results alphabetically.",
+          "aliases": ["lookup_witness_accounts"],
+          "params": [
+            {
+              "name": "lower_bound_name",
+              "caption": "Lower Bound Name",
+              "description": "The lower bound of the first account name to return. Use empty string to start from the beginning.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 1000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Set of validator account names matching the query."
+          }
+        }
+      ]
+    },
+    {
+      "name": "account_history",
+      "description": "Tracks operations by account and provides per-account operation history queries.",
+      "methods": [
+        {
+          "method": "get_account_history",
+          "description": "Returns a map of operations for a given account in the sequence range [from-limit, from]. Each account operation has a sequence number starting from 0. Use from=-1 (4294967295) to get the most recent operations.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name whose operation history to retrieve.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "from",
+              "caption": "From Sequence",
+              "description": "The absolute sequence number. Use -1 (4294967295) for the most recent operation.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of operations to return. Must be between 1 and 1000. Must be less than 'from' unless from is -1.",
+              "type": "integer",
+              "required": true,
+              "minimum": 1,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "Map of sequence number to applied_operation objects for the account."
+          }
+        }
+      ]
+    },
+    {
+      "name": "operation_history",
+      "description": "Tracks all blockchain operations and provides block-level and transaction-level operation queries.",
+      "methods": [
+        {
+          "method": "get_ops_in_block",
+          "description": "Returns the sequence of operations included or generated within a particular block. Virtual operations are generated by the blockchain (e.g. rewards) as opposed to user-submitted operations.",
+          "params": [
+            {
+              "name": "block_num",
+              "caption": "Block Number",
+              "description": "Height of the block whose operations should be returned.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "only_virtual",
+              "caption": "Only Virtual",
+              "description": "Whether to only include virtual operations in the returned results.",
+              "type": "boolean",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of applied_operation objects from the specified block."
+          }
+        },
+        {
+          "method": "get_transaction",
+          "description": "Returns a transaction by its ID, including block number and transaction index within the block.",
+          "params": [
+            {
+              "name": "id",
+              "caption": "Transaction ID",
+              "description": "The hash (SHA-256 / ripemd160) of the transaction to retrieve.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "annotated_signed_transaction with block_num and transaction_num fields added."
+          }
+        }
+      ]
+    },
+    {
+      "name": "database_api",
+      "description": "The core read-only API for the blockchain database. Provides access to blocks, accounts, chain properties, authority validation, vesting delegations, and more.",
+      "methods": [
+        {
+          "method": "get_block_header",
+          "description": "Retrieves a block header by block number.",
+          "params": [
+            {
+              "name": "block_num",
+              "caption": "Block Number",
+              "description": "Height of the block whose header should be returned.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The block header, or null if no matching block was found.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "get_block",
+          "description": "Retrieves a full, signed block by block number.",
+          "params": [
+            {
+              "name": "block_num",
+              "caption": "Block Number",
+              "description": "Height of the block to be returned.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The full signed block, or null if no matching block was found.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "get_irreversible_block_header",
+          "description": "Retrieves a block header only if the block is irreversible. Returns null if the block has not yet been finalized.",
+          "params": [
+            {
+              "name": "block_num",
+              "caption": "Block Number",
+              "description": "Height of the block whose header should be returned.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The block header if the block is irreversible, or null.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "get_irreversible_block",
+          "description": "Retrieves a full, signed block only if it is irreversible. Returns null if the block has not yet been finalized.",
+          "params": [
+            {
+              "name": "block_num",
+              "caption": "Block Number",
+              "description": "Height of the block to be returned.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The full signed block if irreversible, or null.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "set_block_applied_callback",
+          "description": "Sets a callback function that is triggered on each newly generated block. Used for real-time block notifications via WebSocket.",
+          "params": [
+            {
+              "name": "callback",
+              "caption": "Callback",
+              "description": "Callback function to invoke when a new block is applied.",
+              "type": "function",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "null",
+            "description": "No return value (callback-based)."
+          }
+        },
+        {
+          "method": "get_config",
+          "description": "Retrieves compile-time constants and configuration values of the blockchain (e.g., chain ID, symbol, precision).",
+          "params": [],
+          "returns": {
+            "type": "object",
+            "description": "Object containing blockchain compile-time configuration constants."
+          }
+        },
+        {
+          "method": "get_dynamic_global_properties",
+          "description": "Retrieves the current dynamic global properties object, which contains real-time chain state such as head block number, total supply, and other dynamic metrics.",
+          "params": [],
+          "returns": {
+            "type": "object",
+            "description": "The dynamic_global_property_api_object with current chain state."
+          }
+        },
+        {
+          "method": "get_chain_properties",
+          "description": "Retrieves the chain properties as set by the median validator schedule (chain-wide constraints like account creation fee, maximum block size, etc.).",
+          "params": [],
+          "returns": {
+            "type": "object",
+            "description": "chain_api_properties object with median chain parameters."
+          }
+        },
+        {
+          "method": "get_hardfork_version",
+          "description": "Returns the current hardfork version of the blockchain.",
+          "params": [],
+          "returns": {
+            "type": "string",
+            "description": "The current hardfork version string (e.g. '0.23.0')."
+          }
+        },
+        {
+          "method": "get_next_scheduled_hardfork",
+          "description": "Returns the next scheduled hardfork version and the time it is planned to go live.",
+          "params": [],
+          "returns": {
+            "type": "object",
+            "description": "Object with hf_version (string) and live_time (ISO timestamp)."
+          }
+        },
+        {
+          "method": "get_accounts",
+          "description": "Returns full account objects for a list of account names. Includes balances, vesting, authority, and validator votes.",
+          "params": [
+            {
+              "name": "names",
+              "caption": "Account Names",
+              "description": "Array of account names to look up.",
+              "type": "array",
+              "items": { "type": "string" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of account_api_object entries. Only accounts that exist are returned."
+          }
+        },
+        {
+          "method": "lookup_account_names",
+          "description": "Looks up accounts by their names. Returns an optional account object for each name; null if the account does not exist.",
+          "params": [
+            {
+              "name": "account_names",
+              "caption": "Account Names",
+              "description": "Array of account names to look up.",
+              "type": "array",
+              "items": { "type": "string" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of optional account_api_object entries. Each element may be null."
+          }
+        },
+        {
+          "method": "lookup_accounts",
+          "description": "Looks up account names starting from a lower bound. Returns a set of account names in alphabetical order.",
+          "params": [
+            {
+              "name": "lower_bound_name",
+              "caption": "Lower Bound Name",
+              "description": "The lower bound of the first account name to return.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 1000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Set of account names matching the query."
+          }
+        },
+        {
+          "method": "get_account_count",
+          "description": "Returns the total number of accounts registered on the blockchain.",
+          "params": [],
+          "returns": {
+            "type": "integer",
+            "description": "Total number of registered accounts."
+          }
+        },
+        {
+          "method": "get_master_history",
+          "description": "Returns the master authority change history for a given account, useful for account recovery audits.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name whose master authority history to retrieve.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of master_authority_history_api_object entries."
+          }
+        },
+        {
+          "method": "get_recovery_request",
+          "description": "Returns the current account recovery request for an account, if one exists.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name whose recovery request to check.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The account_recovery_request_api_object, or null if no request exists.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "get_escrow",
+          "description": "Returns the escrow object for a given sender and escrow ID.",
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Account",
+              "description": "The account name of the escrow sender.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "escrow_id",
+              "caption": "Escrow ID",
+              "description": "The numeric escrow ID to look up.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "The escrow_api_object, or null if not found.",
+            "nullable": true
+          }
+        },
+        {
+          "method": "get_withdraw_routes",
+          "description": "Returns vesting withdrawal routes for a given account. Can filter by direction (incoming, outgoing, or all).",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name whose withdrawal routes to retrieve.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "type",
+              "caption": "Route Type",
+              "description": "Filter direction: 'incoming', 'outgoing', or 'all'.",
+              "type": "string",
+              "enum": ["incoming", "outgoing", "all"],
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of withdraw_route objects with from_account, to_account, percent, auto_vest."
+          }
+        },
+        {
+          "method": "get_vesting_delegations",
+          "description": "Returns vesting delegation objects for a given account. Supports pagination and filtering by delegated or received.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The delegator or delegatee account name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "from",
+              "caption": "From",
+              "description": "The account name to start from for pagination.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results. Defaults to 100. Must not exceed 1000.",
+              "type": "integer",
+              "required": false,
+              "default": 100,
+              "maximum": 1000
+            },
+            {
+              "name": "type",
+              "caption": "Delegation Type",
+              "description": "Filter type: 'delegated' (sent) or 'received'. Defaults to 'delegated'.",
+              "type": "string",
+              "enum": ["delegated", "received"],
+              "required": false,
+              "default": "delegated"
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of vesting_delegation_api_object entries."
+          }
+        },
+        {
+          "method": "get_expiring_vesting_delegations",
+          "description": "Returns expiring vesting delegation objects for a given account, starting from a given date.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The delegator account name.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "from",
+              "caption": "From Date",
+              "description": "Start date/time for expiration lookup (ISO timestamp).",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results. Defaults to 100. Must not exceed 1000.",
+              "type": "integer",
+              "required": false,
+              "default": 100,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of vesting_delegation_expiration_api_object entries."
+          }
+        },
+        {
+          "method": "get_transaction_hex",
+          "description": "Returns a hexadecimal dump of the serialized binary form of a transaction.",
+          "params": [
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction object to serialize.",
+              "type": "object",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "string",
+            "description": "Hex-encoded serialized transaction."
+          }
+        },
+        {
+          "method": "get_required_signatures",
+          "description": "Given a partially signed transaction and a set of available public keys, returns the minimal subset of public keys that should add signatures to authorize the transaction.",
+          "params": [
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction to analyze.",
+              "type": "object",
+              "required": true
+            },
+            {
+              "name": "available_keys",
+              "caption": "Available Keys",
+              "description": "Array/set of public keys that the caller can sign with.",
+              "type": "array",
+              "items": { "type": "string" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Set of public keys that are required to sign the transaction."
+          }
+        },
+        {
+          "method": "get_potential_signatures",
+          "description": "Returns the set of all public keys that could possibly sign for a given transaction. Useful for wallets to filter their key set before calling get_required_signatures.",
+          "params": [
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction to analyze.",
+              "type": "object",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Set of all public keys that could potentially authorize the transaction."
+          }
+        },
+        {
+          "method": "verify_authority",
+          "description": "Verifies that a transaction has all of the required signatures. Returns true if valid, otherwise throws an exception.",
+          "params": [
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction to verify.",
+              "type": "object",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "boolean",
+            "description": "true if the transaction has all required signatures."
+          }
+        },
+        {
+          "method": "verify_account_authority",
+          "description": "Verifies that a set of public keys has sufficient authority to authorize actions on behalf of an account.",
+          "params": [
+            {
+              "name": "name_or_id",
+              "caption": "Account Name",
+              "description": "The account name to check authority for.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "signers",
+              "caption": "Signer Keys",
+              "description": "Array/set of public keys to verify against the account's authority.",
+              "type": "array",
+              "items": { "type": "string" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "boolean",
+            "description": "true if the signers have enough authority to authorize the account."
+          }
+        },
+        {
+          "method": "get_database_info",
+          "description": "Returns database shared memory usage information including total size, free size, reserved size, used size, and per-index record counts.",
+          "params": [],
+          "returns": {
+            "type": "object",
+            "description": "Object with total_size, free_size, reserved_size, used_size, and index_list (array of {name, record_count})."
+          }
+        },
+        {
+          "method": "get_proposed_transactions",
+          "description": "Returns proposed transactions (proposals) associated with a given account, both authored and requiring approval.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name whose proposals to retrieve.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "from",
+              "caption": "From Offset",
+              "description": "Offset for pagination (number of results to skip).",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of proposals to return. Must not exceed 100.",
+              "type": "integer",
+              "required": true,
+              "maximum": 100
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of proposal_api_object entries."
+          }
+        },
+        {
+          "method": "get_accounts_on_sale",
+          "description": "Returns a list of accounts currently on sale (direct sale, not auction). Only accounts whose sale start time has passed are included.",
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Offset",
+              "description": "Number of results to skip for pagination.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 1000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of account_on_sale_api_object entries."
+          }
+        },
+        {
+          "method": "get_accounts_on_auction",
+          "description": "Returns a list of accounts currently on auction (no target buyer set). Only accounts whose sale start time has passed are included.",
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Offset",
+              "description": "Number of results to skip for pagination.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 1000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of account_on_sale_api_object entries for auction listings."
+          }
+        },
+        {
+          "method": "get_subaccounts_on_sale",
+          "description": "Returns a list of subaccounts currently on sale.",
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Offset",
+              "description": "Number of results to skip for pagination.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 1000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of subaccount_on_sale_api_object entries."
+          }
+        }
+      ]
+    },
+    {
+      "name": "account_by_key",
+      "description": "Provides a lookup from public keys to the accounts that reference those keys in their authority.",
+      "methods": [
+        {
+          "method": "get_key_references",
+          "description": "Returns all account names that reference the given public keys in their master, active, or regular authority.",
+          "params": [
+            {
+              "name": "keys",
+              "caption": "Public Keys",
+              "description": "Array of public keys to look up.",
+              "type": "array",
+              "items": { "type": "string" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of arrays of account names. Each inner array corresponds to one input key and contains all accounts referencing that key."
+          }
+        }
+      ]
+    },
+    {
+      "name": "network_broadcast_api",
+      "description": "Provides transaction and block broadcasting capabilities. This is the write API for submitting transactions to the network.",
+      "methods": [
+        {
+          "method": "broadcast_transaction",
+          "description": "Broadcasts a signed transaction to the network. The transaction is accepted into the pending pool and propagated to P2P peers. Optionally checks that the blockchain is not too far behind.",
+          "params": [
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction to broadcast.",
+              "type": "object",
+              "required": true
+            },
+            {
+              "name": "max_block_age",
+              "caption": "Max Block Age",
+              "description": "Optional. Maximum allowed age of the head block in seconds. If the blockchain is behind by more than this, the call will fail. Use -1 to disable.",
+              "type": "integer",
+              "required": false
+            }
+          ],
+          "returns": {
+            "type": "null",
+            "description": "No return value on success."
+          }
+        },
+        {
+          "method": "broadcast_transaction_synchronous",
+          "description": "Broadcasts a signed transaction and waits for confirmation. Returns the transaction ID, block number, and transaction index once included in a block. The callback includes whether the transaction expired.",
+          "params": [
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction to broadcast.",
+              "type": "object",
+              "required": true
+            },
+            {
+              "name": "max_block_age",
+              "caption": "Max Block Age",
+              "description": "Optional. Maximum allowed age of the head block in seconds. Use -1 to disable.",
+              "type": "integer",
+              "required": false
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "Object with id (transaction hash), block_num, trx_num, and expired fields."
+          }
+        },
+        {
+          "method": "broadcast_block",
+          "description": "Broadcasts a signed block to the network. Typically used by validators to propagate newly produced blocks.",
+          "params": [
+            {
+              "name": "block",
+              "caption": "Block",
+              "description": "The signed block to broadcast.",
+              "type": "object",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "null",
+            "description": "No return value on success."
+          }
+        },
+        {
+          "method": "broadcast_transaction_with_callback",
+          "description": "Broadcasts a signed transaction with a confirmation callback. The first argument is the callback, followed by the transaction. Similar to broadcast_transaction_synchronous but with custom callback handling.",
+          "params": [
+            {
+              "name": "callback",
+              "caption": "Callback",
+              "description": "Confirmation callback function.",
+              "type": "function",
+              "required": true
+            },
+            {
+              "name": "trx",
+              "caption": "Transaction",
+              "description": "The signed transaction to broadcast.",
+              "type": "object",
+              "required": true
+            },
+            {
+              "name": "max_block_age",
+              "caption": "Max Block Age",
+              "description": "Optional. Maximum allowed age of the head block in seconds. Use -1 to disable.",
+              "type": "integer",
+              "required": false
+            }
+          ],
+          "returns": {
+            "type": "null",
+            "description": "No direct return; result delivered via callback."
+          }
+        }
+      ]
+    },
+    {
+      "name": "committee_api",
+      "description": "Provides access to committee worker proposal requests and their voting state.",
+      "methods": [
+        {
+          "method": "get_committee_request",
+          "description": "Returns a committee request by its ID, optionally including votes.",
+          "params": [
+            {
+              "name": "request_id",
+              "caption": "Request ID",
+              "description": "The numeric ID of the committee request to retrieve.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "votes_count",
+              "caption": "Votes Count",
+              "description": "Number of votes to include. Use 0 for no votes, -1 for all votes, or a positive number to limit.",
+              "type": "integer",
+              "required": false,
+              "default": 0
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "committee_api_object with optional embedded votes array."
+          }
+        },
+        {
+          "method": "get_committee_request_votes",
+          "description": "Returns all votes for a specific committee request.",
+          "params": [
+            {
+              "name": "request_id",
+              "caption": "Request ID",
+              "description": "The numeric ID of the committee request whose votes to retrieve.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of committee_vote_state objects."
+          }
+        },
+        {
+          "method": "get_committee_requests_list",
+          "description": "Returns a list of committee request IDs filtered by status.",
+          "params": [
+            {
+              "name": "status",
+              "caption": "Status",
+              "description": "The status code to filter by (e.g. 0=pending, 1=approved, etc.).",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "description": "Array of committee request IDs matching the given status."
+          }
+        }
+      ]
+    },
+    {
+      "name": "invite_api",
+      "description": "Provides access to invite objects used for account registration via invite keys.",
+      "methods": [
+        {
+          "method": "get_invites_list",
+          "description": "Returns a list of invite IDs filtered by status.",
+          "params": [
+            {
+              "name": "status",
+              "caption": "Status",
+              "description": "The status code to filter invites by.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "integer" },
+            "description": "Array of invite database IDs matching the given status."
+          }
+        },
+        {
+          "method": "get_invite_by_id",
+          "description": "Returns an invite object by its database ID.",
+          "params": [
+            {
+              "name": "id",
+              "caption": "Invite ID",
+              "description": "The database ID of the invite to retrieve.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "invite_api_object with invite details (key, creator, balance, etc.)."
+          }
+        },
+        {
+          "method": "get_invite_by_key",
+          "description": "Returns an invite object by its public key.",
+          "params": [
+            {
+              "name": "key",
+              "caption": "Invite Key",
+              "description": "The public key associated with the invite.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "invite_api_object matching the given key."
+          }
+        }
+      ]
+    },
+    {
+      "name": "paid_subscription_api",
+      "description": "Provides access to paid subscription data: subscription options set by content creators, subscription status of subscribers, and active/inactive subscription lists.",
+      "methods": [
+        {
+          "method": "get_paid_subscription_options",
+          "description": "Returns the paid subscription settings for a given account (creator).",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name of the subscription creator.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "paid_subscription_state with subscription details (price, period, etc.)."
+          }
+        },
+        {
+          "method": "get_paid_subscriptions",
+          "description": "Returns a paginated list of all paid subscription objects.",
+          "params": [
+            {
+              "name": "from",
+              "caption": "From Offset",
+              "description": "Number of results to skip for pagination.",
+              "type": "integer",
+              "required": true
+            },
+            {
+              "name": "limit",
+              "caption": "Limit",
+              "description": "Maximum number of results to return. Must not exceed 1000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 1000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of paid_subscription_object entries."
+          }
+        },
+        {
+          "method": "get_paid_subscription_status",
+          "description": "Returns the subscription status of a specific subscriber for a given creator account.",
+          "params": [
+            {
+              "name": "subscriber",
+              "caption": "Subscriber",
+              "description": "The account name of the subscriber.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "account",
+              "caption": "Creator Account",
+              "description": "The account name of the subscription creator.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "paid_subscribe_state with subscription status details."
+          }
+        },
+        {
+          "method": "get_active_paid_subscriptions",
+          "description": "Returns a list of creator account names that a given subscriber has active subscriptions to.",
+          "params": [
+            {
+              "name": "subscriber",
+              "caption": "Subscriber",
+              "description": "The account name of the subscriber.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Array of creator account names with active subscriptions."
+          }
+        },
+        {
+          "method": "get_inactive_paid_subscriptions",
+          "description": "Returns a list of creator account names that a given subscriber has inactive (expired) subscriptions to.",
+          "params": [
+            {
+              "name": "subscriber",
+              "caption": "Subscriber",
+              "description": "The account name of the subscriber.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Array of creator account names with inactive subscriptions."
+          }
+        }
+      ]
+    },
+    {
+      "name": "custom_protocol_api",
+      "description": "Provides access to account data enriched with custom protocol sequence information. Custom protocols allow third-party applications to track per-account custom operations.",
+      "methods": [
+        {
+          "method": "get_account",
+          "description": "Returns an account object enriched with custom protocol sequence data for a specific custom protocol ID. Populates custom_sequence and custom_sequence_block_num fields.",
+          "params": [
+            {
+              "name": "account",
+              "caption": "Account Name",
+              "description": "The account name to look up.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "custom_protocol_id",
+              "caption": "Custom Protocol ID",
+              "description": "The custom protocol ID string to retrieve the sequence for. Use empty string to skip custom protocol lookup.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "account_api_object with custom_sequence and custom_sequence_block_num populated for the given protocol."
+          }
+        }
+      ]
+    },
+    {
+      "name": "auth_util",
+      "description": "Provides utility methods for verifying account authority signatures against arbitrary data digests.",
+      "methods": [
+        {
+          "method": "check_authority_signature",
+          "description": "Verifies that the provided signatures are valid for the given account's authority at a specified level (master, active, or regular). Returns the public keys derived from the signatures.",
+          "params": [
+            {
+              "name": "account_name",
+              "caption": "Account Name",
+              "description": "The account name whose authority to check.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "level",
+              "caption": "Authority Level",
+              "description": "The authority level to verify against: 'master' (or 'm'), 'active' (or 'a'), 'regular' (or 'r'). Empty string defaults to 'active'.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "dig",
+              "caption": "Digest",
+              "description": "The SHA-256 hash of the data that was signed.",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "sigs",
+              "caption": "Signatures",
+              "description": "Array of signatures to verify.",
+              "type": "array",
+              "items": { "type": "string" },
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Array of public keys recovered from the valid signatures."
+          }
+        }
+      ]
+    },
+    {
+      "name": "block_info",
+      "description": "Tracks block metadata (size, average block size, slot info) and provides queries to retrieve this information for ranges of blocks.",
+      "methods": [
+        {
+          "method": "get_block_info",
+          "description": "Returns block metadata (block_id, block_size, average_block_size, aslot, last_irreversible_block_num) for a range of blocks starting from start_block_num.",
+          "params": [
+            {
+              "name": "start_block_num",
+              "caption": "Start Block Number",
+              "description": "The first block number to return info for. Must be greater than 0.",
+              "type": "integer",
+              "required": true,
+              "minimum": 1
+            },
+            {
+              "name": "count",
+              "caption": "Count",
+              "description": "Number of blocks to return info for. Must not exceed 10000.",
+              "type": "integer",
+              "required": true,
+              "maximum": 10000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of block_info objects. Entries may be empty if no info is stored (e.g. blocks before snapshot)."
+          }
+        },
+        {
+          "method": "get_blocks_with_info",
+          "description": "Returns full signed blocks with attached metadata for a range. Limits total response size to 8 MB. Stops early if no info is stored for a block.",
+          "params": [
+            {
+              "name": "start_block_num",
+              "caption": "Start Block Number",
+              "description": "The first block number to return. Must be greater than 0.",
+              "type": "integer",
+              "required": true,
+              "minimum": 1
+            },
+            {
+              "name": "count",
+              "caption": "Count",
+              "description": "Maximum number of blocks to return. Must not exceed 10000. Response is capped at 8 MB total.",
+              "type": "integer",
+              "required": true,
+              "maximum": 10000
+            }
+          ],
+          "returns": {
+            "type": "array",
+            "description": "Array of block_with_info objects, each containing a signed block and its block_info metadata."
+          }
+        }
+      ]
+    },
+    {
+      "name": "raw_block",
+      "description": "Provides access to raw (base64-encoded) serialized block data for low-level block inspection or re-import.",
+      "methods": [
+        {
+          "method": "get_raw_block",
+          "description": "Returns a raw block by block number, including the base64-encoded serialized binary, block ID, previous block ID, and timestamp.",
+          "params": [
+            {
+              "name": "block_num",
+              "caption": "Block Number",
+              "description": "Height of the block to retrieve in raw form.",
+              "type": "integer",
+              "required": true
+            }
+          ],
+          "returns": {
+            "type": "object",
+            "description": "Object with block_id, previous, timestamp, and raw_block (base64-encoded string) fields."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/.qoder/docs/spec/prediction-market-library-integration-spec.md
+++ b/.qoder/docs/spec/prediction-market-library-integration-spec.md
@@ -1,0 +1,1138 @@
+# Prediction Markets (Onix, HF14) — Library Integration Specification
+
+> **Audience:** implementers of the JS / PHP / Python client libraries.
+> **Goal:** everything a library needs to (a) build & sign prediction-market transactions and
+> (b) read prediction-market state over JSON-RPC — operation names, plugin names, API method
+> names, parameters, and the full field layout of every operation and returned object.
+>
+> This document is generated from the node source and is authoritative for field **names,
+> order, and types**. It intentionally does **not** re-explain the economic mechanics
+> (CPMM/LMSR/parimutuel, leverage math, dispute game theory) — for that see
+> `docs/prediction-markets/specification.md`. Here we describe *the wire contract only*.
+
+---
+
+## 1. Conventions
+
+### 1.1 Data types
+
+| Spec type | Wire (JSON) representation | Notes |
+|---|---|---|
+| `account_name_type` | string | 3–25 chars, VIZ account name |
+| `asset` | string `"10.000 VIZ"` | VIZ, **3 decimals**, `TOKEN_SYMBOL = VIZ`. Serialized as `"<amount>.<3 decimals> VIZ"` |
+| `share_type` | integer (int64) | raw amount, **already scaled by 1000** (i.e. `10.000 VIZ` = `10000`). Used inside read-only objects |
+| `pm_object_id_type` | integer (int64) | plain numeric id of a pm object (market/bet/liquidity/…). NOT the `space.type.instance` string form |
+| `<obj>_id_type` (in returned objects) | string `"<space>.<type>.<instance>"` OR integer, depending on serializer | ChainBase object id. In practice compare/pass the numeric instance. See §1.4 |
+| `time_point_sec` | string ISO-8601 `"2026-07-02T12:00:00"` (UTC, no `Z`) | seconds precision |
+| `fc::sha256` | hex string (64 chars) | |
+| `fc::uint128_t` | integer or string | may exceed JS `Number.MAX_SAFE_INTEGER` — use big-int/string |
+| `uint16_t` percent (bp) | integer | **basis points**, `10000 = 100.00%` unless noted otherwise |
+| `extensions_type` | array `[]` | always present, always empty for HF14; include as `[]` when signing |
+
+**Percent conventions differ by field — read the per-field notes.** Three scales appear:
+- **bp (basis points):** `10000 = 100%`. Most fee/percent fields.
+- **`time_penalty` on a bet:** `1e6 = 100%` (`pm_max_time_penalty = 1000000`).
+- **`pm_leverage_*_percent` governance knobs:** plain percent (`10 = 10%`), see §9.
+
+### 1.2 Operation serialization
+
+Operations are members of a single `static_variant` (tagged union). Two encodings:
+
+- **JSON (what libraries build):** a 2-element array `["<op_name>", { ...fields }]`, where
+  `<op_name>` is the struct name **with the `_operation` suffix removed** — e.g.
+  `pm_place_bet_operation` → `"pm_place_bet"`.
+- **Binary (for signing):** the variant **tag is a varint = the op-id** in §2/§3, followed by
+  the fields in the exact declared order. Field order in every table below **is** the binary
+  order. `extensions` is the last field of user ops (empty vector → single `0x00` byte).
+
+A transaction's `operations` array holds these 2-element arrays. Signing (ref-block, expiration,
+chain-id, canonical secp256k1) is identical to every other VIZ operation — unchanged by HF14.
+
+### 1.3 JSON-RPC calling convention
+
+All reads go through the **`prediction_market_api`** plugin. Call shape (same as every VIZ API
+plugin):
+
+```json
+{ "jsonrpc":"2.0", "id":1, "method":"call",
+  "params":["prediction_market_api", "<method>", [ <positional args...> ]] }
+```
+
+Positional args are order-sensitive; trailing optional args may be omitted. Pagination is
+uniformly `(…key…, from, limit)` with `limit ≤ 1000`.
+
+### 1.4 Object ids
+
+Returned objects carry an `id`. The numeric **instance** part is what you pass back into ops as
+`market_id`, `bet_id`, `liquidity_id`, `position_id`, `commit_id`. When reading you may receive
+either the string `"space.type.instance"` or a bare integer depending on the serializer build;
+always be able to parse the trailing integer. Ops take the bare integer (`pm_object_id_type`).
+
+---
+
+## 2. Plugins & node configuration
+
+| Plugin (config `plugin =` name) | Role |
+|---|---|
+| `chain` | consensus DB (always on) |
+| `json_rpc` | RPC transport (always on) |
+| `prediction_market_api` | **all PM read methods** (§5). Requires `chain` + `json_rpc` |
+
+`prediction_market_api` config option (`config.ini`):
+
+| Option | Default | Meaning |
+|---|---|---|
+| `pmm-ttl-days` | `7` | Days to keep a market's non-consensus metadata + kline history after its dispute window closes, then pruned |
+
+There is **no separate operations plugin** — PM operations are part of the core protocol
+(`operation` variant); any node accepting transactions accepts them once HF14 is active.
+
+---
+
+## 3. User (signed) operations
+
+35 total PM operations exist; **23 are user operations** (submitted in transactions), 12 are
+virtual (§4). Op-id = index in the global `operation` variant (fixed, append-only).
+
+Legend for **Auth**: which authority must sign — `active` (spending auth) or `regular` (posting-level auth).
+
+| # | op-id | JSON name | Auth | Purpose |
+|---|---|---|---|---|
+| 1 | 66 | `pm_oracle_register` | active(`owner`) | Register an oracle with a bonded insurance deposit |
+| 2 | 67 | `pm_oracle_update` | active(`owner`) | Change insurance / fees / rules / auto-accept policy |
+| 3 | 68 | `pm_create_market` | active(`creator`) | Create a market; creator seeds first liquidity |
+| 4 | 69 | `pm_oracle_accept_market` | active(`oracle`) | Oracle accepts/rejects a pending market & quotes terms |
+| 5 | 70 | `pm_place_bet` | active(`account`) | Place a bet (instant or batch) |
+| 6 | 71 | `pm_commit_bet` | active(`account`) | Commit-reveal phase 1: hidden commitment |
+| 7 | 72 | `pm_reveal_bet` | active(`account`) | Commit-reveal phase 2: reveal & enqueue |
+| 8 | 73 | `pm_cancel_bet` | active(`account`) | Cancel an open/queued bet (needs `allow_cancellation`) |
+| 9 | 74 | `pm_add_liquidity` | active(`provider`) | Add liquidity to a market |
+| 10 | 75 | `pm_withdraw_liquidity` | active(`provider`) | Withdraw liquidity |
+| 11 | 76 | `pm_resolve_market` | active(`oracle`) | Oracle resolves to a winning outcome |
+| 12 | 77 | `pm_no_contest` | active(`oracle`) | Oracle voids the market (refund all) |
+| 13 | 78 | `pm_dispute_create` | active(`disputer`) | File a dispute (escrows `pm_dispute_fee`) |
+| 14 | 79 | `pm_dispute_vote` | **regular**(`voter`) | Committee-mode dispute vote |
+| 15 | 80 | `pm_dispute_resolve` | active(`resolver`) | Account-mode dispute verdict by configured resolver |
+| 16 | 81 | `pm_transfer_position` | active(`from`) | Transfer bet weight to another account |
+| 17 | 82 | `pm_lazy_deposit` | active(`account`) | Deposit into the lazy liquidity pool |
+| 18 | 83 | `pm_lazy_withdraw` | active(`account`) | Withdraw from the lazy pool |
+| 19 | 91 | `pm_leverage_open` | active(`account`) | Open a leveraged CPMM position |
+| 20 | 92 | `pm_leverage_close` | active(`account`) | Voluntarily close a leveraged position |
+| 21 | 93 | `pm_leverage_convert` | active(`account`) | Convert a leveraged position to a normal bet |
+| 22 | 98 | `pm_dispute_oracle_respond` | active(`oracle`) | Oracle posts a public rebuttal on an open dispute |
+| 23 | 99 | `pm_unban` | active(`resolver`) | Lift an oracle/creator ban set by that resolver |
+
+> Op-ids 84–90 and 94–97 are the **virtual** ops interleaved in the variant (§4). The user-op
+> op-ids above are therefore not fully contiguous. Always verify the numeric tag against a live
+> node if you hand-roll binary serialization; JSON name-based serialization is the safe path.
+
+Below, each op lists its fields **in declared (binary) order**. All ops end with
+`extensions: []` (omitted from the tables). Percent fields are bp unless noted.
+
+### 3.1 `pm_oracle_register`
+| Field | Type | Description |
+|---|---|---|
+| `owner` | account | Oracle account; also the required signer |
+| `insurance` | asset | VIZ bond locked from `owner`; must be `≥ pm_min_oracle_insurance` |
+| `fee_percent` | uint16 (bp) | Oracle % of losers' pool; `≤ pm_max_oracle_fee_percent` |
+| `fixed_fee` | asset | Per-market fixed fee (VIZ, `≥ 0`) |
+| `rules_url` | string | Oracle rules/profile URL; `≤ 256` chars |
+| `auto_accept_creator` | account | Auto-accept only markets from this creator; empty = any |
+| `auto_accept_resolver` | account | Empty = auto-accept committee-mode markets only; set = only account-mode markets whose `dispute_resolver` equals this |
+| `auto_accept` | bool | Enable the anti-collusion auto-accept policy above |
+
+### 3.2 `pm_oracle_update`
+All change fields are **optional** — omit to leave unchanged.
+| Field | Type | Description |
+|---|---|---|
+| `owner` | account | Oracle account (signer) |
+| `insurance_delta` | optional asset | Signed: `>0` top-up, `<0` withdraw. Withdraw blocked while active markets exist or if it would drop below `pm_min_oracle_insurance` |
+| `fee_percent` | optional uint16 (bp) | New oracle fee % |
+| `fixed_fee` | optional asset | New per-market fixed fee |
+| `rules_url` | optional string | New rules URL |
+| `auto_accept_creator` | optional account | Update auto-accept policy |
+| `auto_accept_resolver` | optional account | Update auto-accept policy |
+| `auto_accept` | optional bool | Enable/disable auto-accept |
+
+### 3.3 `pm_create_market`
+Oracle terms here are the creator's **offer ceiling** (max the maker will pay). The oracle locks
+its actual quote (`≤` these) at accept; a self-oracle freezes them as-is at creation.
+| Field | Type | Description |
+|---|---|---|
+| `creator` | account | Market creator (signer); becomes first LP |
+| `oracle` | account | Registered oracle, or `creator` for a self-oracle |
+| `market_type` | uint8 | `0` binary (CPMM), `1` multi (LMSR) |
+| `outcomes` | string[] | Outcome labels. Size **2** for binary; `3..pm_max_outcomes` for multi. Each label `≤ 64` chars |
+| `url` | string | Resolution criteria/title; `≤ 256` chars |
+| `oracle_fee_percent` | uint16 (bp) | Offered max oracle % of losers' pool |
+| `oracle_fixed_fee` | asset | Offered max oracle fixed fee (VIZ, `≥ 0`) |
+| `creator_fee_percent` | uint16 (bp) | Creator's cut of losers' pool |
+| `liquidity_fee_percent` | uint16 (bp) | LP cut of losers' pool |
+| `liquidity` | asset | VIZ seed liquidity; `≥ pm_min_liquidity` |
+| `lmsr_b` | share_type | Multi only: client-computed LMSR `b`. Node checks `floor(liquidity / ln_q(N)) == b`. `0` for binary |
+| `betting_expiration` | time_point_sec | Betting closes at this time |
+| `result_expiration` | time_point_sec | `> betting_expiration`; `≤ now + pm_max_market_duration` |
+| `time_penalty_type` | uint8 | Time-decay penalty model selector |
+| `time_penalty_value` | uint32 | Penalty parameter (see market mechanics) |
+| `penalty_curve_type` | uint8 | Penalty curve selector |
+| `allow_early_resolution` | bool | Oracle may resolve before `betting_expiration` |
+| `allow_cancellation` | bool | Bettors may cancel open bets |
+| `allow_batch` | bool | Allow batch (commit-reveal / queued) betting |
+| `allow_instant_bet` | bool | Allow instant bets. **Multi forces `true`** (no LMSR batch yet) |
+| `endogeneity_tier` | uint8 | `1` econ-data / `2` sports / `3` political |
+| `dispute_mode` | uint8 | `0` committee / `1` account |
+| `dispute_resolver` | account | Required & must exist iff `dispute_mode==1`; must NOT equal `oracle` or `creator` |
+| `dispute_penalty_percent` | int16 (bp) | `−10000..+10000` oracle penalty policy on a successful dispute: `>0` slash % of insurance ×consensus; `<0` good-faith bonus from fee; `0` none |
+| `metadata` | string | Free-form client JSON (no length cap). Consensus-opaque; parsed off-chain by the meta plugin (see §6) |
+
+### 3.4 `pm_oracle_accept_market`
+Quote fields are ignored on reject and for self-oracle markets.
+| Field | Type | Description |
+|---|---|---|
+| `oracle` | account | Oracle (signer) |
+| `market_id` | int64 | Target market |
+| `accept` | bool | `true` accept, `false` reject |
+| `oracle_fee_percent` | uint16 (bp) | Oracle's quoted %; `≤` market offer & the median cap |
+| `oracle_fixed_fee` | asset | Oracle's quoted fixed fee; `≤` market offer |
+
+Emits virtual `pm_market_accepted` on accept.
+
+### 3.5 `pm_place_bet`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Bettor (signer) |
+| `market_id` | int64 | Target market |
+| `side` | int8 | Binary: `0`/`1`. Multi: `-1` |
+| `outcome_index` | int16 | Multi: `0..N-1`. Binary: `-1` |
+| `amount` | asset | Stake (VIZ, `> 0`) |
+| `min_tokens` | share_type | Slippage floor on received weight (`0` = none) |
+| `mode` | uint8 | `0` instant, `1` batch (queued to next epoch) |
+
+### 3.6 `pm_commit_bet`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Bettor (signer) |
+| `market_id` | int64 | Target market |
+| `commitment` | sha256 | SHA-256 of the exact binary preimage in §3.6.1 (consensus-critical) |
+| `escrow_amount` | asset | VIZ locked; `≥ pm_min_batch_bet` |
+| `no_reveal_fee_percent` | uint16 (bp) | **MUST equal** median(`pm_commit_no_reveal_penalty_percent`) — consensus-checked |
+
+#### 3.6.1 Commitment preimage (byte-exact — must match consensus)
+
+The node recomputes this hash in the `pm_reveal_bet` evaluator (`verify_commit` in
+`libraries/chain/pm_evaluator.cpp`) and rejects the reveal on any mismatch — a wrong preimage
+**forfeits the escrow**. The preimage is a **raw binary concatenation with no separators and no
+length prefixes** (it is *not* the colon-delimited string some prototypes used). Fields, in order:
+
+| # | Field | Bytes | Encoding |
+|---|---|---|---|
+| 1 | `market_id` | 8 | int64, **little-endian** (the numeric market instance) |
+| 2 | `account` | 32 | ASCII account name left-aligned in a **32-byte** buffer, **zero-padded** (VIZ `fixed_string_32` storage) |
+| 3 | `side` | 1 | int8 (binary: `0`/`1`; multi: `-1` = `0xFF`) |
+| 4 | `outcome_index` | 2 | int16, **little-endian** (multi: `0..N-1`; binary: `-1` = `0xFFFF`) |
+| 5 | `amount` | 8 | int64, little-endian — the **revealed** amount in **milli-VIZ** (`asset.amount`, i.e. VIZ×1000) |
+| 6 | `min_tokens` | 8 | int64, little-endian (milli-VIZ / weight units) |
+| 7 | `salt` | variable | raw UTF-8/byte content of the salt string (its own length, no terminator) |
+
+Fixed portion = **59 bytes**; total = `59 + len(salt)`. `commitment = SHA-256(preimage)` (32-byte
+digest). The same `side`, `outcome_index`, `amount`, `min_tokens`, `salt` must be re-supplied in
+`pm_reveal_bet` (§3.7). Integers use **little-endian** because the node hashes raw host bytes on its
+(x86-64, little-endian) consensus platform — libraries MUST emit little-endian regardless of host.
+
+**Golden test vector** (verify your encoder against this before shipping):
+
+```
+market_id      = 5
+account        = "alice"
+side           = 0
+outcome_index  = -1
+amount         = 10000        # 10.000 VIZ
+min_tokens     = 0
+salt           = "cafe1234"
+
+preimage (hex, 67 bytes):
+0500000000000000 616c696365000000000000000000000000000000000000000000000000000000 00 ffff 1027000000000000 0000000000000000 6361666531323334
+
+commitment = SHA-256(preimage)
+           = acc2fbc9e024509a529584baba41dc2eabdb82c3c107dc041d37c94b24f4b3c0
+```
+
+(Preimage shown space-grouped by field for readability; concatenate without spaces before hashing.)
+
+### 3.7 `pm_reveal_bet`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Bettor (signer) |
+| `commit_id` | int64 | The `pm_commit` object being revealed |
+| `side` | int8 | Same value that was committed |
+| `outcome_index` | int16 | Same value that was committed |
+| `amount` | asset | `≤ escrow_amount`; surplus refunded |
+| `salt` | string | Entropy bound into the commitment hash |
+| `min_tokens` | share_type | Slippage floor |
+
+### 3.8 `pm_cancel_bet`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Bettor (signer) |
+| `bet_id` | int64 | Bet to cancel |
+| `min_return` | share_type | Slippage floor on the refund |
+
+### 3.9 `pm_add_liquidity`
+| Field | Type | Description |
+|---|---|---|
+| `provider` | account | LP (signer) |
+| `market_id` | int64 | Target market |
+| `amount` | asset | VIZ to add (`> 0`) |
+
+### 3.10 `pm_withdraw_liquidity`
+| Field | Type | Description |
+|---|---|---|
+| `provider` | account | LP (signer) |
+| `liquidity_id` | int64 | LP position to withdraw from |
+| `amount` | asset | VIZ to withdraw; `0` = full position. Principal-safe; locked from `betting_expiration` until resolution |
+
+### 3.11 `pm_resolve_market`
+| Field | Type | Description |
+|---|---|---|
+| `oracle` | account | Oracle (signer) |
+| `market_id` | int64 | Target market |
+| `winning_outcome` | int16 | Winning outcome index |
+| `decision_url` | string | Evidence/decision URL; `≤ 256` chars. Stored on the market (`pm_market_object.decision_url`) |
+| `decision_reason` | string | Free-text justification; `≤ 1024` chars. Stored on the market (`pm_market_object.decision_reason`), readable via `get_market` |
+
+### 3.12 `pm_no_contest`
+| Field | Type | Description |
+|---|---|---|
+| `oracle` | account | Oracle (signer) |
+| `market_id` | int64 | Target market |
+| `reason` | string | `≤ 1024` chars. Stored on the market as `decision_reason` |
+
+### 3.13 `pm_dispute_create`
+| Field | Type | Description |
+|---|---|---|
+| `disputer` | account | Disputer (signer); escrows `pm_dispute_fee` |
+| `market_id` | int64 | Target market |
+| `proposed_outcome` | int16 | Outcome the disputer claims is correct (`-1` = void/no-contest challenge) |
+| `reason` | string | `≤ 1024` chars |
+
+### 3.14 `pm_dispute_vote` (committee mode)
+Signed with **regular** authority (like `committee_vote_request`). Ballots are revisable until
+voting closes (modify-or-create).
+| Field | Type | Description |
+|---|---|---|
+| `voter` | account | Voter (regular-auth signer) |
+| `market_id` | int64 | Disputed market |
+| `vote_outcome` | int16 | Correct outcome, or `-1` to uphold the oracle |
+| `vote_percent` | int16 | Conviction / penalty intensity `[-10000, 10000]` (bp). Sign encodes direction; see §5 `get_dispute_votes` for tally semantics |
+
+### 3.15 `pm_dispute_resolve` (account mode)
+Verdict by the market's configured `dispute_resolver`.
+| Field | Type | Description |
+|---|---|---|
+| `resolver` | account | Configured resolver (signer) |
+| `market_id` | int64 | Disputed market |
+| `correct_outcome` | int16 | Final correct outcome |
+| `penalty_amount` | asset | Oracle insurance to slash |
+| `ban_oracle` | bool | Ban the oracle |
+| `ban_oracle_until` | time_point_sec | Oracle ban expiry (`time_point_sec::maximum()` = permanent) |
+| `ban_creator` | bool | Ban the creator from creating markets |
+| `ban_creator_until` | time_point_sec | Creator ban expiry (max = permanent) |
+
+> **Bans are a compliance/regulator feature, exclusive to account mode.** When a market routes
+> disputes to an account-mode `dispute_resolver` (e.g. a regulator or a licensed arbitrator), that
+> resolver can sanction **both the oracle and the market creator** — temporarily or permanently
+> (`*_until = maximum()`) — in the same verdict, on top of the insurance slash. This lets a regulator
+> that serves as resolver enforce off-chain rules (bar a bad-faith oracle or a repeat-offender
+> creator from the platform). **Committee/DAO mode (`dispute_mode = 0`) has no ban power by design**
+> — it is a transparent public hearing that only slashes insurance and dings reputation
+> (`pm_dispute_finalize`); it never bans. A ban set here records the issuing `resolver` in the
+> target's `banned_by`, so only that resolver may lift it early via `pm_unban` (§3.23); otherwise it
+> lapses at `banned_until` (cron emits `pm_ban_expired`, §4.12).
+
+### 3.16 `pm_transfer_position`
+| Field | Type | Description |
+|---|---|---|
+| `from` | account | Current holder (signer) |
+| `bet_id` | int64 | Bet whose weight is transferred |
+| `to` | account | Recipient |
+| `amount` | share_type | Weight to reassign; `0` = full. No market impact |
+| `memo` | string | Plaintext, or `#`-prefixed ECIES (same as VIZ memos) |
+
+### 3.17 `pm_lazy_deposit`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Depositor (signer) |
+| `amount` | asset | VIZ deposited into the lazy pool (`> 0`) |
+
+### 3.18 `pm_lazy_withdraw`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Depositor (signer) |
+| `shares` | share_type | Pool shares to burn; `0` = all |
+| `emergency` | bool | `true` = withdraw before lock ends, with penalty on locked-share profit |
+
+### 3.19 `pm_leverage_open`
+Gated by `pm_leverage_enabled`.
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Bettor (signer) |
+| `market_id` | int64 | Target market (binary CPMM only) |
+| `outcome_index` | int16 | Binary side `0`/`1` |
+| `collateral` | asset | Bettor's own stake (VIZ) |
+| `loan` | asset | Pool loan (VIZ) |
+| `min_tokens` | share_type | Slippage floor (consensus-checked) |
+| `max_slippage_percent` | uint16 (bp) | User-facing front-run guard |
+
+### 3.20 `pm_leverage_close`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Position owner (signer) |
+| `position_id` | int64 | Leverage position to close (only if `cancel_value ≥ liquidation_threshold`) |
+| `min_return` | share_type | Slippage floor on the bettor's return |
+
+### 3.21 `pm_leverage_convert`
+| Field | Type | Description |
+|---|---|---|
+| `account` | account | Position owner (signer) |
+| `position_id` | int64 | Leverage position to convert to a normal bet |
+| `conversion_profit_cost` | uint16 (bp) | **MUST equal** median(`pm_conversion_profit_cost_percent`) |
+
+### 3.22 `pm_dispute_oracle_respond`
+The market's oracle posts a public rebuttal onto the open dispute. Stored on the dispute object
+(read via `get_dispute`); allowed only while the dispute is open and `now ≤ oracle_response_deadline`.
+Re-posting overwrites the previous response.
+| Field | Type | Description |
+|---|---|---|
+| `oracle` | account | Market oracle (signer) |
+| `market_id` | int64 | Disputed market |
+| `response` | string | Rebuttal text; non-empty, `≤ 1024` chars |
+
+### 3.23 `pm_unban`
+Lifts a ban imposed by an account-mode `pm_dispute_resolve`. Only the resolver recorded in the
+target's `banned_by` may lift it. At least one of `unban_oracle` / `unban_creator` must be true.
+| Field | Type | Description |
+|---|---|---|
+| `resolver` | account | The resolver that imposed the ban (signer); must equal the target's `banned_by` |
+| `target` | account | The banned oracle / creator account |
+| `unban_oracle` | bool | Clear the oracle ban (`pm_oracle_object.banned_until`) |
+| `unban_creator` | bool | Clear the creator ban (`pm_creator_ban_object.banned_until`) |
+
+---
+
+## 4. Virtual operations
+
+Virtual ops are **never submitted** by clients — they are emitted deterministically by the
+node's bounded per-block cron and appear in block/account history (via the account-history /
+operation-history plugins, `get_ops_in_block`, etc.). Libraries need to **parse** them.
+They have no `extensions` field.
+
+| op-id | JSON name | Emitted when |
+|---|---|---|
+| 84 | `pm_batch_settle` | Epoch boundary: queued/revealed bets settle at a uniform price |
+| 85 | `pm_commit_forfeit` | An unrevealed commitment forfeits its penalty into `forfeit_pool` |
+| 86 | `pm_auto_payout` | Deferred market-level payout marker after the dispute grace elapses |
+| 87 | `pm_dispute_finalize` | Committee-mode tally finalized at `voting_end_time` |
+| 88 | `pm_dispute_auto_close` | Anti-freeze: dispute unresolved at `auto_close_time` → full refund |
+| 89 | `pm_oracle_missed_penalty` | Oracle missed `result_expiration` → insurance slashed, refund all |
+| 90 | `pm_lazy_recall` | Lazy-pool graduated recall step (idle allocation returned) |
+| 94 | `pm_leverage_liquidate` | A leveraged position force-closed (opposing bet / cancel / expiration) |
+| 95 | `pm_leverage_resolve` | A leveraged position settled at market resolution |
+| 96 | `pm_market_accepted` | Oracle accepted (or self-oracle auto-accepted); terms frozen |
+| 97 | `pm_payout` | Per-bettor parimutuel settlement (one per active bet inside settle) |
+| 100 | `pm_ban_expired` | A temporary oracle/creator ban lapsed at `banned_until`; the cron cleared it |
+
+### 4.1 `pm_batch_settle`
+`market_id` (int64), `epoch` (uint32), `settled_bets` (uint32).
+
+### 4.2 `pm_commit_forfeit`
+`account`, `commit_id` (int64), `market_id` (int64), `penalty` (asset → `forfeit_pool`), `refund` (asset → account).
+
+### 4.3 `pm_auto_payout`
+`account`, `market_id` (int64), `bet_id` (int64), `payout` (asset).
+
+### 4.4 `pm_dispute_finalize`
+`market_id` (int64), `winning_outcome` (int16), `oracle_penalty` (asset).
+
+### 4.5 `pm_dispute_auto_close`
+`market_id` (int64), `oracle_penalty` (asset).
+
+### 4.6 `pm_oracle_missed_penalty`
+`oracle`, `market_id` (int64), `slashed` (asset).
+
+### 4.7 `pm_lazy_recall`
+`market_id` (int64), `recalled` (asset).
+
+### 4.8 `pm_leverage_liquidate`
+`account`, `position_id` (int64), `market_id` (int64), `cancel_value` (asset), `pool_received` (asset),
+`bettor_received` (asset), `reason` (uint8: `0` opposing_bet, `1` cancel_bet, `2` expiration).
+
+### 4.9 `pm_leverage_resolve`
+`account`, `position_id` (int64), `market_id` (int64), `won` (bool), `pool_received` (asset),
+`bettor_received` (asset), `outcome_index` (int16), `leverage` (uint16 — integer multiple `total_bet/collateral`).
+`won` = position was solvent; `bettor_received == 0` ⇒ collateral lost.
+
+### 4.10 `pm_market_accepted`
+`oracle`, `creator`, `market_id` (int64), `oracle_fee_percent` (uint16 bp, frozen),
+`oracle_fixed_fee` (asset, frozen), `self_oracle` (bool — `true` = auto-accepted at creation).
+
+### 4.11 `pm_payout`
+`account`, `market_id` (int64), `bet_id` (int64), `side` (int8: binary `0`/`1`, multi `-1`),
+`outcome_index` (int16: multi `0..N-1`, binary `-1`), `amount` (asset — the stake),
+`payout` (asset — credited at settle; `0` on a loss).
+
+### 4.12 `pm_ban_expired`
+`account`, `oracle` (bool), `creator` (bool). Emitted by the per-block cron when a **temporary**
+oracle and/or creator ban reaches `banned_until` — the cron clears the ban and fires this so
+history/indexers observe the lift. An *early manual* lift is the signed `pm_unban` op instead (§3.23),
+so this vop fires only for automatic time-expiry. Permanent bans (`banned_until = maximum()`) never
+expire and never emit it.
+
+---
+
+## 5. API methods — `prediction_market_api` plugin
+
+Call as `call("prediction_market_api", "<method>", [args])`. `from`/`limit` are pagination
+offsets; `limit ≤ 1000`. Returned object schemas are in §7.
+
+### Markets
+
+**`get_market(market_id)`**
+- `market_id` int64.
+- Returns `pm_market_object` (§7.2). Throws if not found.
+
+**`list_markets(status, from, limit, [show_risky=false])`**
+- `status` int8 — filter by market status (`-1` deleted, `0` waiting, `1` active, `2` closed, `3` resolved).
+- `from` uint32, `limit` uint32.
+- `show_risky` bool (optional) — when `false` (default), markets whose oracle insurance covers
+  `< 2.5×` their betting volume are **hidden**. `true` reveals them.
+- Returns `pm_market_object[]`.
+
+**`list_markets_by_oracle(oracle, from, limit)`** → `pm_market_object[]` for `oracle` (account name).
+
+**`list_markets_by_creator(creator, from, limit)`** → `pm_market_object[]` for `creator` (account name).
+
+**`get_market_outcomes(market_id)`** → `pm_outcome_object[]` (§7.3), ordered by `outcome_index`.
+
+**`get_market_weight_sums(market_id)`** → `pm_market_weight_sums_api_object` (§7.16). Per-outcome
+aggregated staked amount and curve weight (computed live from active/resolved bets). For binary
+markets the outcome labels are synthesized as `"A"`/`"B"`.
+
+**`get_market_bets(market_id, from, limit)`** → `pm_bet_object[]` (§7.4), all bets on the market.
+
+**`get_account_positions(account, from, limit)`** → `pm_position_api_object[]` (§7.15) — each
+bet plus its `expected_payout` (parimutuel projection mirroring settlement) and the market status.
+
+**`get_market_liquidity(market_id, from, limit)`** → `pm_liquidity_object[]` (§7.5).
+
+**`get_market_full(market_id, [account])`** → `pm_market_full_api_object` (§7.24). One-call enriched
+view: market + outcomes + weight sums + oracle (with reliability) + parsed metadata, plus — when
+`account` is given — that account's bets / leverage positions / LP **on this market**. Saves the thin
+client several round-trips when opening a market detail screen. Throws only if the market is missing.
+
+### Leverage
+
+**`get_account_leverage_positions(account, from, limit)`** → `pm_leverage_position_object[]` (§7.12).
+
+**`get_market_leverage_positions(market_id, from, limit)`** → `pm_leverage_position_object[]` (§7.12).
+
+**`get_creator_ban(account)`** → `pm_creator_ban_object` (§7.13). Throws if the account is not banned.
+
+**`get_leverage_quote(market_id, outcome_index, collateral)`** → `pm_leverage_quote_api_object` (§7.20).
+Read-only projection of `pm_leverage_open` using the **same in-node margin math**: the max solvent
+loan, the resulting max leverage, the pool/position caps, and up to 12 slider stops (each with
+tokens, threshold, current & worst-case cancel value). `collateral` is a `share_type` integer
+(milli-VIZ). When leverage is not possible, `available=false` and `failed_constraints[]` explains
+why. Throws only if the market does not exist.
+
+**`get_leverage_close_preview(position_id)`** → `pm_leverage_close_preview_api_object` (§7.21).
+Mirrors `pm_leverage_close` at head-block reserves: cancel value, pool obligation, what the bettor
+receives, and `closeable` (false ⇒ the protocol would liquidate instead).
+
+**`get_leverage_convert_preview(position_id)`** → `pm_leverage_convert_preview_api_object` (§7.22).
+Mirrors `pm_leverage_convert`: cancel value, current profit, the conversion fee at the current
+median `pm_conversion_profit_cost_percent`, and the `total_user_payment` the convert op would debit.
+
+> These three are **non-consensus quotes** — reserves move between the read and the broadcast, so
+> treat the numbers as an estimate at the head block and always send the on-chain slippage guards
+> (`min_tokens` / `min_return` / `conversion_profit_cost`).
+
+### Oracles
+
+**`get_oracle(owner)`** → `pm_oracle_api_object` (§7.14) — the raw `pm_oracle_object` plus a
+non-consensus `reliability_score` (bp `[0..10000]`). `owner` = account name. Throws if not found.
+
+**`list_oracles(from, limit)`** → `pm_oracle_object[]` (§7.1), ordered by owner name.
+
+### Disputes
+
+**`get_dispute(market_id)`** → `pm_dispute_object` (§7.7). Throws if no dispute exists.
+
+**`get_dispute_votes(market_id)`** → `pm_dispute_votes_api_object` (§7.17). Returns the live
+ballot list **plus** a stake-weighted projection of what the finalize cron would apply right now
+(quorum status, expected outcome, consensus strength). Safe to call when no dispute exists
+(returns defaults). Key semantics of the vote tally:
+- A vote with `vote_outcome == -1` (or `vote_percent ≤ 0`) counts as **defending the oracle**.
+- A vote with `vote_percent > 0` and a valid `vote_outcome` backs an **outcome change**, weighted
+  by `voter_shares × vote_percent / 10000`.
+- Voter weight = `effective_vesting_shares + lazy-pool stake→shares`.
+
+### Lazy pool & chain properties
+
+**`get_lazy_pool()`** (no args) → `pm_lazy_pool_object` (§7.9). Throws if the pool is uninitialized.
+
+**`get_lazy_deposit(account)`** → `pm_lazy_deposit_object` (§7.10). Throws if the account has no deposit.
+
+**`get_lazy_allocations(from, limit)`** → `pm_lazy_allocation_object[]` (§7.11). All lazy-pool
+per-market allocation records (for a pool dashboard).
+
+**`get_market_lazy_allocation(market_id)`** → `pm_lazy_allocation_object` (§7.11). The lazy-pool
+allocation for one market. Throws if none.
+
+> Oracle penalty stamps are already on `pm_oracle_object` (`penalty_stamps`, `last_penalty_stamp_time`,
+> returned by `get_oracle`) — no separate method needed.
+
+**`get_pm_chain_properties()`** (no args) → `chain_properties_pm` (§9) — the **median** (active,
+consensus) values of every PM governance parameter.
+
+### Metadata & charts (non-consensus, plugin-indexed)
+
+**`get_market_meta(market_id)`** → `pm_market_meta_object` (§7.18) — parsed category/tags/etc.
+Throws if none indexed yet.
+
+**`list_markets_by_category(category, from, limit, [jurisdiction=""], [subcategory=""], [tag=""], [sort="newest"])`**
+→ `pm_market_meta_object[]`. Optional filters: `jurisdiction` (ISO code — exclude markets banning
+it), `subcategory` (exact match), `tag` (CSV membership). `sort` ∈ `newest` (market id desc,
+default) · `oldest` (id asc) · `volume` (`bets_sum` desc) · `expiration` (`betting_expiration` asc).
+`volume`/`expiration` load each matching market, so they scan the whole (non-pruned) category
+before paging.
+
+**`get_market_categories()`** (no args) → `pm_market_categories_api_object` (§7.23). Category taxonomy
+with live per-category / per-subcategory counts, plus the top 20 hot tags (jurisdiction-* tags
+excluded), aggregated over the currently indexed (non-pruned) markets. Use it to build the browse
+filter chips without hard-coding a taxonomy.
+
+**`get_market_kline(market_id, [from=0], [limit=1000])`** → `pm_kline_api_object[]` (§7.19).
+Time-series of per-outcome weight snapshots, ascending by `seq` (oldest→newest). Pagination is
+**offset-from-newest**: `from` skips the newest N points, then up to `limit` are returned. So
+`(from=0, limit=1000)` is the latest ≤1000 changes; `(from=1000, limit=1000)` steps another 1000
+back. Empty array when the market has no recorded points.
+
+---
+
+## 6. `metadata` JSON (client convention)
+
+The `metadata` field of `pm_create_market` is consensus-opaque free-form JSON. The
+`prediction_market_api` plugin parses these keys (unknown keys ignored) and exposes them via
+`get_market_meta` / `list_markets_by_category`:
+
+| Key | Type | Indexed as |
+|---|---|---|
+| `category` | string | `category` (queryable) |
+| `subcategory` | string | `subcategory` |
+| `tags` | string[] or CSV | `tags` (comma-joined) |
+| `banned_jurisdictions` | string[] or CSV of ISO codes | `banned_jurisdictions` (filtered in `list_markets_by_category`) |
+
+Any other keys (title translations, images, source links, etc.) are preserved on-chain in
+`metadata` verbatim but not indexed. Localization is a pure client concern.
+
+---
+
+## 7. Returned object schemas
+
+Field order below matches the node's reflection (JSON key order is not guaranteed, but these are
+the exact keys). All monetary fields are `share_type` **integers** (raw, ×1000) unless the type
+says `asset`.
+
+### 7.1 `pm_oracle_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | Oracle id |
+| `owner` | account | Oracle account |
+| `insurance` | share_type | Locked insurance bond |
+| `fee_percent` | uint16 (bp) | Oracle % of losers' pool |
+| `fixed_fee` | share_type | Per-market fixed fee |
+| `rules_url` | string | Rules/profile URL |
+| `active_since` | time | First activation time |
+| `last_active_time` | time | Last activity time |
+| `banned_until` | time | `0` not banned; `time_point_sec::maximum()` = permanent |
+| `markets_accepted` | uint32 | Reputation counter |
+| `markets_resolved` | uint32 | Reputation counter |
+| `no_contest_count` | uint32 | Markets voided |
+| `missed_count` | uint32 | Missed resolution deadlines |
+| `disputes_received` | uint32 | Disputes filed against this oracle |
+| `disputes_lost` | uint32 | Disputes where oracle was overturned |
+| `disputes_won` | uint32 | Disputes where oracle was upheld |
+| `disputes_auto_closed` | uint32 | Disputes that hit auto-close |
+| `dispute_responses_missed` | uint32 | Missed dispute-response deadlines |
+| `total_volume_resolved` | share_type | Cumulative resolved volume |
+| `total_insurance_slashed` | share_type | Cumulative insurance slashed |
+| `avg_resolution_time` | uint32 | Avg seconds to resolve |
+| `penalty_stamps` | uint32 | Active penalty stamps (10-day decay) |
+| `bans_received` | uint32 | Ban count |
+| `last_penalty_stamp_time` | time | Time of most recent penalty stamp |
+| `auto_accept_creator` | account | Auto-accept policy (empty = any) |
+| `auto_accept_resolver` | account | Auto-accept policy |
+| `auto_accept` | bool | Auto-accept enabled |
+| `banned_by` | account | Resolver that set `banned_until` (empty if unset); the account allowed to `pm_unban` |
+
+### 7.2 `pm_market_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | Market id |
+| `creator` | account | Creator |
+| `oracle` | account | Oracle |
+| `market_type` | uint8 | `0` binary (CPMM), `1` multi (LMSR) |
+| `outcome_count` | uint8 | Number of outcomes (binary = 2) |
+| `url` | string | Resolution criteria/title |
+| `status` | int8 | `-1` deleted, `0` waiting, `1` active, `2` closed, `3` resolved |
+| `payout_status` | uint8 | `0` none, `1` pending, `2` paid, `3` disputed |
+| `created_time` | time | Creation time |
+| `betting_expiration` | time | Betting closes |
+| `result_expiration` | time | Oracle deadline |
+| `resolved_outcome` | int16 | Winning outcome; `-1` if unresolved |
+| `reserve_a` | share_type | Binary CPMM reserve A |
+| `reserve_b` | share_type | Binary CPMM reserve B |
+| `k` | uint128 | CPMM invariant `reserve_a × reserve_b` |
+| `a_bets_sum` | share_type | Binary: total staked on side A |
+| `b_bets_sum` | share_type | Binary: total staked on side B |
+| `lmsr_b` | share_type | Multi: LMSR liquidity parameter |
+| `lmsr_subsidy` | share_type | Multi: LMSR subsidy |
+| `bets_sum` | share_type | Total staked across all outcomes |
+| `liquidity_sum` | share_type | Total LP liquidity |
+| `oracle_fee_percent` | uint16 (bp) | Frozen oracle fee % |
+| `creator_fee_percent` | uint16 (bp) | Creator fee % |
+| `liquidity_fee_percent` | uint16 (bp) | LP fee % |
+| `oracle_fixed_fee` | share_type | Frozen oracle fixed fee |
+| `liquidity_fee_earned` | share_type | Accrued LP fees |
+| `forfeit_pool` | share_type | Forfeited commit penalties added to winners' pool |
+| `time_penalty_type` | uint8 | Time-decay penalty model |
+| `time_penalty_value` | uint32 | Penalty parameter |
+| `penalty_curve_type` | uint8 | Penalty curve |
+| `allow_early_resolution` | bool | |
+| `allow_cancellation` | bool | |
+| `allow_batch` | bool | |
+| `allow_instant_bet` | bool | |
+| `endogeneity_tier` | uint8 | `1`/`2`/`3` |
+| `current_epoch` | uint32 | Current batch epoch |
+| `dispute_mode` | uint8 | `0` committee / `1` account |
+| `dispute_resolver` | account | Configured resolver (account mode) |
+| `dispute_penalty_percent` | int16 (bp) | Oracle penalty policy on successful dispute |
+| `metadata` | string | Raw client JSON |
+| `decision_url` | string | Oracle's cited evidence link, set at resolution (empty until resolved) |
+| `decision_reason` | string | Oracle's free-text justification, set at `pm_resolve_market` (or the NO-CONTEST reason at `pm_no_contest`). Stored on-chain, readable via `get_market` |
+
+### 7.3 `pm_outcome_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `market` | object-id | Owning market |
+| `outcome_index` | uint8 | Index within the market |
+| `label` | string | Outcome label |
+| `q` | share_type | LMSR quantity |
+| `bets_sum` | share_type | Total staked on this outcome |
+| `weight_sum` | share_type | Total curve weight on this outcome |
+| `bets_count` | uint32 | Number of bets |
+
+### 7.4 `pm_bet_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | Bet id |
+| `market` | object-id | Owning market |
+| `account` | account | Bettor |
+| `side` | int8 | Binary: `0`/`1`; multi: `-1` |
+| `outcome_index` | int16 | Multi: `0..N-1`; binary: `-1` |
+| `amount` | share_type | Stake |
+| `weight` | share_type | Curve weight received |
+| `price` | uint64 | Execution price (fixed-point) |
+| `time_penalty` | uint32 | Time penalty (`1e6 = 100%`) |
+| `mode` | uint8 | `0` instant, `1` batch |
+| `epoch` | uint32 | Batch epoch (for queued bets) |
+| `status` | uint8 | `0` active, `1` cancelled, `2` refunded, `3` resolved, `5` queued, `6` revealed-pending |
+| `min_tokens` | share_type | Slippage floor for queued batch bets |
+| `resolved_amount` | share_type | Realized payout after settlement |
+| `created_time` | time | |
+
+### 7.5 `pm_liquidity_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | LP position id |
+| `market` | object-id | Owning market |
+| `provider` | account | LP account; **empty = Lazy Pool** |
+| `amount` | share_type | Provided liquidity |
+| `weight_a` | share_type | Binary reserve share A |
+| `weight_b` | share_type | Binary reserve share B |
+| `b_share` | share_type | LMSR share |
+| `sec_to_expiration` | uint32 | Position term |
+| `deposit_time` | time | |
+| `earned_fee` | share_type | Accrued fees |
+| `status` | uint8 | `0` active, `3` resolved/closed |
+
+### 7.6 `pm_commit_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `market` | object-id | Owning market |
+| `account` | account | Committer |
+| `commitment` | sha256 | Commitment hash |
+| `escrow_amount` | share_type | Locked escrow |
+| `no_reveal_fee_percent` | uint16 (bp) | Snapshotted penalty % at commit |
+| `commit_time` | time | |
+| `reveal_deadline` | time | |
+| `status` | uint8 | `0` committed, `1` revealed, `2` forfeited |
+
+> Note: there is no direct "get_commit" API method in HF14; commits surface via history/virtual ops.
+
+### 7.7 `pm_dispute_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `market` | object-id | Disputed market |
+| `disputer` | account | Who filed |
+| `dispute_fee` | share_type | Escrowed fee |
+| `reason` | string | Dispute reason |
+| `filed_time` | time | |
+| `oracle_response_deadline` | time | Oracle must respond by |
+| `dispute_mode` | uint8 | `0` committee / `1` account |
+| `voting_end_time` | time | Committee voting closes |
+| `auto_close_time` | time | Anti-freeze fallback |
+| `proposed_outcome` | int16 | Outcome the disputer proposes |
+| `status` | uint8 | `0` open, `1` oracle-wrong, `2` oracle-right, `3` auto-closed |
+| `oracle_response` | string | Oracle's public rebuttal (empty until it responds via `pm_dispute_oracle_respond`) |
+| `oracle_response_time` | time | When the rebuttal was posted (`0` = none) |
+
+### 7.8 `pm_dispute_vote_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `market` | object-id | Disputed market |
+| `voter` | account | Voter |
+| `vote_outcome` | int16 | Correct outcome, or `-1` = uphold oracle |
+| `vote_percent` | int16 | Conviction/penalty `[-10000, 10000]` |
+| `time` | time | Vote time |
+
+### 7.9 `pm_lazy_pool_object` (singleton, id 0)
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | Always instance 0 |
+| `total_shares` | share_type | Total pool shares outstanding |
+| `free_balance` | share_type | Unallocated VIZ |
+| `allocated_balance` | share_type | VIZ allocated into markets |
+| `earned_balance` | share_type | Cumulative earnings (monotonic) |
+| `reward_per_share` | uint128 | Reward accumulator (`LAZY_POOL_PRECISION = 1e9`) |
+| `leverage_fund_used` | share_type | Total active leverage loans |
+
+### 7.10 `pm_lazy_deposit_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `account` | account | Depositor |
+| `shares` | share_type | Pool shares held |
+| `principal` | share_type | Original deposited principal |
+| `reward_snapshot` | uint128 | Reward accumulator snapshot |
+| `pending_rewards` | share_type | Unclaimed rewards |
+| `unlock_time` | time | Lock expiry (`pm_lazy_lock_sec` after deposit) |
+
+### 7.11 `pm_lazy_allocation_object`
+Per-market lazy-pool allocation record. Readable via `get_lazy_allocations` (list) and
+`get_market_lazy_allocation(market_id)` (§5).
+`id`, `market`, `amount`, `original_amount`, `recalled_amount`, `returned_amount`,
+`bets_sum_at_check`, `check_step` (uint32 `0..10`), `last_check_time` (time), `status` (uint8: `0` active, `1` returned).
+
+### 7.12 `pm_leverage_position_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | Position id |
+| `market` | object-id | Owning market |
+| `account` | account | Position owner |
+| `outcome_index` | int16 | Binary side `0`/`1` |
+| `collateral` | share_type | Bettor's own stake |
+| `loan` | share_type | Pool loan |
+| `total_bet` | share_type | `collateral + loan` deployed |
+| `tokens` | share_type | Weight received from the AMM |
+| `bet` | object-id | Underlying `pm_bet` id |
+| `pool_profit` | share_type | `loan × R%` |
+| `liquidation_threshold` | share_type | `loan × (1 + R%)` |
+| `status` | uint8 | `0` active, `1` liquidated, `2` resolved_won, `3` resolved_lost, `4` closed_voluntary, `5` converted |
+| `liquidated_at` | time | |
+| `liquidated_by_bet` | object-id | The opposing bet that triggered liquidation |
+| `cancel_value_at_liquidation` | share_type | |
+| `pool_received` | share_type | VIZ returned to pool at close |
+| `bettor_received` | share_type | VIZ returned to bettor at close |
+| `created_time` | time | |
+| `last_update` | time | |
+
+### 7.13 `pm_creator_ban_object`
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `creator` | account | Banned creator |
+| `banned_until` | time | Ban expiry (`maximum()` = permanent; a past time = not banned) |
+| `ban_count` | uint32 | Number of bans received |
+| `banned_by` | account | Resolver that set the current ban (the account allowed to `pm_unban`) |
+
+### 7.14 `pm_oracle_api_object` (from `get_oracle`)
+| Field | Type | Description |
+|---|---|---|
+| `oracle` | `pm_oracle_object` | The raw oracle object (§7.1) |
+| `reliability_score` | uint32 (bp) | Non-consensus heuristic `[0..10000]`: blends resolution success and dispute-win ratios, minus `1000` per ban |
+
+### 7.15 `pm_position_api_object` (from `get_account_positions`)
+| Field | Type | Description |
+|---|---|---|
+| `bet` | `pm_bet_object` | The bet (§7.4) |
+| `expected_payout` | share_type | Parimutuel payout if this side wins (or realized payout once settled). Mirrors settlement exactly |
+| `market_status` | int8 | The market's `status` |
+| `resolved_outcome` | int16 | The market's `resolved_outcome` (`-1` if unresolved) |
+
+### 7.16 `pm_market_weight_sums_api_object` (from `get_market_weight_sums`)
+| Field | Type | Description |
+|---|---|---|
+| `market_type` | uint8 | `0` binary / `1` multi |
+| `bets_sum` | share_type | Total staked |
+| `outcomes` | `pm_weight_entry[]` | Per-outcome breakdown |
+
+`pm_weight_entry`: `outcome_index` (int16), `label` (string), `bets_sum` (share_type), `weight_sum` (share_type).
+
+### 7.17 `pm_dispute_votes_api_object` (from `get_dispute_votes`)
+| Field | Type | Description |
+|---|---|---|
+| `votes` | `pm_dispute_vote_object[]` | All ballots (§7.8) |
+| `uphold_weight` | int64 | **Legacy** rough tally (Σ`|vote_percent|` upholding oracle) |
+| `challenge_weight` | int64 | Legacy: Σ`|vote_percent|` backing a change |
+| `total_weight` | int64 | `uphold + challenge` (legacy) |
+| `challenger_leads` | bool | Legacy: challenge share ≥ approve-min |
+| `proposed_outcome` | int16 | Disputer's proposed outcome |
+| `participation_shares` | int64 | Σ voter weight (vesting-shares) that has voted |
+| `electorate_shares` | int64 | `total_vesting_shares + pool_NAV→shares` (quorum base) |
+| `quorum_required_shares` | int64 | `electorate × pm_dispute_approve_min_percent` |
+| `quorum_percent_bp` | int32 | `participation / electorate` (bp) |
+| `quorum_reached` | bool | `participation ≥ quorum_required` |
+| `oracle_defense_shares` | int64 | Σ rshares defending the oracle |
+| `change_shares` | int64 | Σ rshares backing an outcome change |
+| `outcome_change_shares` | int64[] | Per-outcome backing rshares (size = `outcome_count`) |
+| `expected_uphold` | bool | `true` ⇒ oracle resolution stands if finalized now |
+| `expected_outcome` | int16 | Outcome that would be set at finalize now |
+| `expected_consensus_strength_bp` | int32 | `winning / participation` (bp); `0` when uphold |
+
+### 7.18 `pm_market_meta_object` (from `get_market_meta` / `list_markets_by_category`)
+| Field | Type | Description |
+|---|---|---|
+| `id` | object-id | |
+| `market` | object-id | Owning market |
+| `category` | string | Parsed from metadata JSON |
+| `subcategory` | string | |
+| `tags` | string | Comma-joined |
+| `banned_jurisdictions` | string | Comma-joined ISO codes; empty = allowed everywhere |
+| `expiry` | time | Prune time (dispute window close + TTL) |
+
+### 7.19 `pm_kline_api_object` (from `get_market_kline`)
+| Field | Type | Description |
+|---|---|---|
+| `seq` | uint32 | 0-based contiguous index of the change within the market |
+| `timestamp` | uint32 | **Unix seconds** (x coordinate) |
+| `reason` | uint8 | `0` bet, `1` cancel, `2` liquidation, `3` batch settle, `4` leverage open, `5` leverage resolve |
+| `bets_sum` | share_type | Total staked across all outcomes at this point |
+| `weights` | share_type[] | Per-outcome staked weight (y values), index = `outcome_index`. For binary: `[a_bets_sum, b_bets_sum]` |
+
+For charting: `x = timestamp`, `y[i] = weights[i]`; implied probability of outcome `i` =
+`weights[i] / Σ weights`.
+
+### 7.20 `pm_leverage_quote_api_object` (from `get_leverage_quote`)
+| Field | Type | Description |
+|---|---|---|
+| `available` | bool | `true` ⇒ `max_loan > 0` (some leverage possible) |
+| `outcome_index` | int16 | Echoed side (0/1) |
+| `collateral` | share_type | Echoed collateral |
+| `max_loan` | share_type | Largest solvent loan (`0` if none qualifies) |
+| `max_leverage_x100` | uint32 | `(collateral+max_loan)/collateral × 100` (`100` = 1.00×) |
+| `pool_free_amount` | share_type | `free_balance − leverage_fund_used` |
+| `fund_available` | share_type | `free_balance × pm_leverage_fund_percent − leverage_fund_used` |
+| `per_position_cap` | share_type | `fund_available × pm_leverage_max_per_position_bp` |
+| `market_position_cap` | share_type | `liquidity_sum × pm_leverage_max_position_ratio_percent` |
+| `pool_profit_percent` | uint16 | `R` (plain %) |
+| `safety_margin_percent` | uint16 | `S` (plain %) |
+| `max_slippage_percent` | uint16 | `SL` (plain %) |
+| `m_factor_percent` | uint16 | worst-opposing m-factor (plain %) |
+| `expiration_buffer_sec` | uint32 | Leverage disabled this long before `betting_expiration` |
+| `auto_close_time` | time | `betting_expiration − buffer` (protocol force-close point) |
+| `stops` | `pm_leverage_stop[]` | Up to 12 solvent slider stops (`0 < loan ≤ max_loan`, ≥1.01×) |
+| `failed_constraints` | `pm_leverage_constraint[]` | Populated when `!available` |
+
+`pm_leverage_stop`: `leverage_x100` (uint32), `loan`, `total_bet`, `expected_tokens`, `pool_profit`,
+`liquidation_threshold`, `current_cancel_value`, `worst_case_cancel_value` (all share_type).
+`pm_leverage_constraint`: `constraint` (string key: `leverage_disabled` / `cpmm_binary_only` /
+`market_inactive` / `expiration_buffer` / `min_market_liquidity` / `fund_availability` /
+`position_size` / `solvency`), `reason` (string).
+
+### 7.21 `pm_leverage_close_preview_api_object` (from `get_leverage_close_preview`)
+| Field | Type | Description |
+|---|---|---|
+| `position_id` | int64 | Echoed position |
+| `outcome_index` | int16 | Position side |
+| `cancel_value` | share_type | VIZ the tokens fetch from the curve now |
+| `pool_obligation` | share_type | `liquidation_threshold` → returned to the pool |
+| `bettor_receives` | share_type | `cancel_value − pool_obligation` (floored 0) |
+| `collateral` | share_type | Original bettor stake |
+| `loan` | share_type | Pool loan |
+| `pool_profit_charge` | share_type | Pool's fixed profit on the loan |
+| `closeable` | bool | `cancel_value ≥ pool_obligation` (else the protocol liquidates) |
+| `loss_vs_collateral` | int64 | `collateral − bettor_receives` (negative = profit) |
+| `loss_percent_bp` | int32 | `loss_vs_collateral / collateral` (bp) |
+
+### 7.22 `pm_leverage_convert_preview_api_object` (from `get_leverage_convert_preview`)
+| Field | Type | Description |
+|---|---|---|
+| `position_id` | int64 | Echoed position |
+| `outcome_index` | int16 | Position side |
+| `cancel_value` | share_type | VIZ the tokens fetch now |
+| `pool_obligation` | share_type | Loan + pool profit (repaid on convert) |
+| `current_profit` | share_type | `cancel_value − pool_obligation` |
+| `conversion_profit_cost_percent` | uint16 | Median value the convert op **must** echo |
+| `conversion_fee` | share_type | `current_profit × cost% / 100` |
+| `total_user_payment` | share_type | `pool_obligation + conversion_fee` (debited on convert) |
+| `convertible` | bool | `current_profit > 0` |
+
+### 7.23 `pm_market_categories_api_object` (from `get_market_categories`)
+| Field | Type | Description |
+|---|---|---|
+| `categories` | `pm_category_count[]` | Sorted by count desc |
+| `hot_tags` | `pm_tag_count[]` | Top 20 tags by count (jurisdiction-* excluded) |
+
+`pm_category_count`: `category` (string), `count` (uint32), `subcategories` (`pm_subcategory_count[]`).
+`pm_subcategory_count`: `subcategory` (string), `count` (uint32).
+`pm_tag_count`: `tag` (string), `count` (uint32).
+
+### 7.24 `pm_market_full_api_object` (from `get_market_full`)
+| Field | Type | Description |
+|---|---|---|
+| `market` | `pm_market_object` | The market (§7.2) |
+| `outcomes` | `pm_outcome_object[]` | Outcomes (§7.3); empty for binary markets |
+| `weight_sums` | `pm_market_weight_sums_api_object` | Per-outcome amount + curve weight (§7.16) |
+| `oracle` | `pm_oracle_api_object` \| null | The market's oracle + reliability (§7.14); null if not found |
+| `meta` | `pm_market_meta_object` \| null | Parsed metadata (§7.18); null if not indexed |
+| `my_positions` | `pm_position_api_object[]` | The `account` arg's bets on this market (empty if no account) |
+| `my_leverage_positions` | `pm_leverage_position_object[]` | The account's leverage positions on this market |
+| `my_liquidity` | `pm_liquidity_object[]` | The account's LP positions on this market |
+
+`oracle` and `meta` are optional (JSON `null` when absent). The `my_*` arrays are empty unless the
+optional `account` argument was supplied.
+
+---
+
+## 8. Enum / status quick reference
+
+| Enum | Values |
+|---|---|
+| `market.market_type` | `0` binary (CPMM), `1` multi (LMSR) |
+| `market.status` | `-1` deleted, `0` waiting, `1` active, `2` closed, `3` resolved |
+| `market.payout_status` | `0` none, `1` pending, `2` paid, `3` disputed |
+| `market.dispute_mode` | `0` committee, `1` account |
+| `market.endogeneity_tier` | `1` econ-data, `2` sports, `3` political |
+| `bet.status` | `0` active, `1` cancelled, `2` refunded, `3` resolved, `5` queued, `6` revealed-pending |
+| `bet.mode` / `place_bet.mode` | `0` instant, `1` batch |
+| `liquidity.status` | `0` active, `3` resolved/closed |
+| `commit.status` | `0` committed, `1` revealed, `2` forfeited |
+| `dispute.status` | `0` open, `1` oracle-wrong, `2` oracle-right, `3` auto-closed |
+| `leverage_position.status` | `0` active, `1` liquidated, `2` resolved_won, `3` resolved_lost, `4` closed_voluntary, `5` converted |
+| `leverage_liquidate.reason` | `0` opposing_bet, `1` cancel_bet, `2` expiration |
+| `lazy_allocation.status` | `0` active, `1` returned |
+| `kline.reason` | `0` bet, `1` cancel, `2` liquidation, `3` batch settle, `4` leverage open, `5` leverage resolve |
+| `dispute_vote.vote_outcome` | `-1` uphold oracle; `≥0` proposed correct outcome |
+
+---
+
+## 9. Chain (governance) properties — `get_pm_chain_properties`
+
+These are median-voted validator params (part of `versioned_chain_properties`). Values shown are
+**mainnet defaults**; a client must read live values via `get_pm_chain_properties`. Assets are
+VIZ; `*_percent` are **bp (10000 = 100%)** unless the row says otherwise.
+
+| Field | Default | Unit | Meaning |
+|---|---|---|---|
+| `pm_oracle_registration_fee` | 10.000 VIZ | asset | Oracle registration fee → committee fund |
+| `pm_min_oracle_insurance` | 5000.000 VIZ | asset | Minimum insurance bond |
+| `pm_market_creation_fee` | 5.000 VIZ | asset | Market creation fee → committee fund |
+| `pm_min_liquidity` | 100.000 VIZ | asset | Minimum seed liquidity |
+| `pm_max_outcomes` | 10 | count | Max outcomes per multi market (`≤ 16`) |
+| `pm_max_market_duration` | 31536000 | sec | Max market lifetime (≤ 1 year) |
+| `pm_max_oracle_fee_percent` | 500 | bp | Cap on oracle fee % (5%) |
+| `pm_listing_min_coverage_percent` | 250 | **coverage %** | Hide markets whose oracle insurance covers < this % of bets (250 = 2.5×); enforced by `list_markets`/`list_markets_by_category` (revealed via `show_risky`) |
+| `pm_betting_min_coverage_percent` | 150 | **coverage %** | Advisory: below this coverage a client should require an explicit risk confirmation. Not enforced on-chain; must be `≤ pm_listing_min_coverage_percent` |
+| `pm_default_time_penalty_percent` | 50 | bp | Default time penalty |
+| `pm_max_time_penalty` | 1000000 | 1e6=100% | Max time penalty on profit |
+| `pm_dispute_fee` | 1000.000 VIZ | asset | Dispute filing fee |
+| `pm_dispute_grace_sec` | 43200 | sec | Payout grace after resolution (12h) |
+| `pm_oracle_dispute_response_sec` | 43200 | sec | Oracle response window (12h) |
+| `pm_dispute_auto_close_sec` | 1209600 | sec | Anti-freeze auto-close (14d) |
+| `pm_dispute_vote_period_sec` | 259200 | sec | Committee voting period (3d) |
+| `pm_dispute_approve_min_percent` | 1000 | bp | Quorum / participation threshold |
+| `pm_oracle_penalty_percent` | 500 | bp | Insurance slashed on missed deadline |
+| `pm_no_contest_penalty_percent` | 5000 | bp | % of dispute fee on no-contest (50%) |
+| `pm_dispute_reward_multiplier` | 30000 | bp | Dispute reward multiplier (10000=1×, default 3×) |
+| `pm_batch_epoch_blocks` | 20 | blocks | Batch epoch length (~60s) |
+| `pm_reveal_window_blocks` | 200 | blocks | Reveal window (~10min) |
+| `pm_commit_no_reveal_penalty_percent` | 2000 | bp | No-reveal penalty → winners' pool (20%) |
+| `pm_min_batch_bet` | 1.000 VIZ | asset | Anti-dust minimum batch bet |
+| `pm_commit_reveal_enabled` | true | bool | Commit-reveal kill-switch |
+| `pm_processing_cap_per_block` | 200 | count | Bounded per-block virtual-op work |
+| `pm_lazy_pool_enabled` | true | bool | Lazy-pool kill-switch |
+| `pm_lazy_alloc_percent` | 2000 | bp | Free balance allocated per market |
+| `pm_lazy_max_total_alloc_percent` | 7000 | bp | Cap on total allocation |
+| `pm_lazy_lock_sec` | 604800 | sec | Deposit lock (7d) |
+| `pm_lazy_recall_step_percent` | 1000 | bp | Recalled per idle step |
+| `pm_lazy_emergency_penalty_percent` | 5000 | bp | Emergency-withdraw penalty on profit |
+| `pm_leverage_enabled` | false | bool | **Leverage kill-switch (off by default)** |
+| `pm_leverage_fund_percent` | 10 | **percent** | % of free balance usable for loans (F) |
+| `pm_leverage_max_per_position_bp` | 20 | bp | Fund-available per position (P=0.2%) |
+| `pm_leverage_pool_profit_percent` | 10 | **percent** | Pool profit per loan (R) |
+| `pm_leverage_safety_margin_percent` | 1 | **percent** | Open-time safety buffer (S) |
+| `pm_leverage_max_slippage_percent` | 10 | **percent** | Max price impact per bet (SL) |
+| `pm_leverage_min_market_liquidity` | 5000.000 VIZ | asset | Min liquidity for leverage |
+| `pm_leverage_max_position_ratio_percent` | 5 | **percent** | Max position as % of `liquidity_sum` |
+| `pm_leverage_expiration_buffer_sec` | 86400 | sec | Leverage disabled N sec before expiration |
+| `pm_leverage_m_factor_percent` | 50 | **percent** | `M_effective = M_max × this%` |
+| `pm_conversion_profit_cost_percent` | 50 | **percent** | Fee % of unrealized profit on convert |
+
+> **Percent-scale trap for library authors:** the `pm_leverage_*` and `pm_conversion_*` knobs use
+> plain percent (`10 = 10%`, validated `≤ 100`), NOT basis points, unlike every other `*_percent`
+> in this table. `pm_leverage_max_per_position_bp` is the one leverage knob that is genuinely bp.
+
+---
+
+## 10. Fixed limits (compile-time, from `config.hpp`)
+
+| Constant | Value | Applies to |
+|---|---|---|
+| `MAX_PM_DECISION_URL_LEN` | 256 | `pm_resolve_market.decision_url` |
+| `MAX_PM_PROFILE_URL_LEN` | 256 | `pm_oracle_register.rules_url` |
+| `MAX_PM_DISPUTE_REASON_LEN` | 1024 | `pm_no_contest.reason`, `pm_dispute_create.reason` |
+| `MAX_PM_MARKET_TITLE_LEN` | 256 | `pm_create_market.url` |
+| `MAX_PM_OUTCOME_LABEL_LEN` | 64 | each `pm_create_market.outcomes[i]` |
+| `MAX_PM_OUTCOMES_PER_MARKET` | 16 | hard ceiling for `pm_max_outcomes` |
+| `LAZY_POOL_PRECISION` | 1e9 | `reward_per_share` accumulator scale |
+
+`metadata` on `pm_create_market` has **no length cap** at the protocol level (like `custom_operation`).
+
+---
+
+## 11. Implementation checklist per library
+
+1. **Operation builders** — 23 user ops (§3), each serialized as `["<name>", {fields}]` in JSON
+   order, with `extensions: []`. Percent-scale per field (§1.1 / §9 trap).
+2. **Asset handling** — VIZ, 3 decimals; format/parse `"x.yyy VIZ"`. Internal `share_type` = ×1000 integer.
+3. **API client** — 29 read methods (§5) via `call("prediction_market_api", …, [args])`, `limit ≤ 1000`.
+4. **Object models** — decode §7 objects; keep `uint128`/large `int64` as big-int/string in JS.
+5. **Virtual-op parsing** — recognize the 12 vops (§4) in account/block history.
+6. **Enums** — map §8 status codes to human labels.
+7. **Metadata** — write the `category`/`subcategory`/`tags`/`banned_jurisdictions` convention (§6).
+8. **Governance** — surface `get_pm_chain_properties` (§9) so UIs read live limits, not hard-coded defaults.
+
+---
+
+*Source of truth (regenerate this doc if these change):*
+`libraries/protocol/include/graphene/protocol/pm_operations.hpp`,
+`pm_virtual_operations.hpp`, `operations.hpp`,
+`libraries/chain/include/graphene/chain/pm_objects.hpp`,
+`libraries/protocol/include/graphene/protocol/chain_operations.hpp` (`chain_properties_pm`),
+`libraries/protocol/include/graphene/protocol/config.hpp` (`MAX_PM_*`),
+`plugins/prediction_market_api/` (`prediction_market_api.{hpp,cpp}`, `meta_object.hpp`, `kline_object.hpp`).

--- a/README.md
+++ b/README.md
@@ -452,4 +452,95 @@ else{
 }
 ```
 
+## Prediction Markets (Onix, HF14)
+
+The library ships all 23 signed prediction-market operations and all 29 `prediction_market_api`
+read methods. Operation builders follow the usual convention (`build_` prefix for queued/proposed
+operations, no prefix to build-and-sign a standalone transaction) and every op takes an empty
+`extensions` vector automatically. Object ids (`market_id`, `bet_id`, `liquidity_id`,
+`position_id`, `commit_id`) are the bare integer instance of the on-chain object.
+
+Percent fields are basis points (`10000 = 100%`) unless a builder note says otherwise. Assets are
+VIZ strings (`"10.000 VIZ"`); `share_type`/`min_tokens` args are raw milli-VIZ integers (VIZ×1000).
+
+### Operation builders
+
+`pm_oracle_register` · `pm_oracle_update` · `pm_create_market` · `pm_oracle_accept_market` ·
+`pm_place_bet` · `pm_commit_bet` · `pm_reveal_bet` · `pm_cancel_bet` · `pm_add_liquidity` ·
+`pm_withdraw_liquidity` · `pm_resolve_market` · `pm_no_contest` · `pm_dispute_create` ·
+`pm_dispute_vote` (regular auth) · `pm_dispute_resolve` · `pm_transfer_position` · `pm_lazy_deposit` ·
+`pm_lazy_withdraw` · `pm_leverage_open` · `pm_leverage_close` · `pm_leverage_convert` ·
+`pm_dispute_oracle_respond` · `pm_unban`.
+
+```php
+<?php
+include('./class/autoloader.php');
+$creator='test';
+$active_key='5K...';//active
+
+$tx=new VIZ\Transaction('https://api.viz.world/',$active_key);
+
+//create a binary (CPMM) market, self-oracle, seeded with 100 VIZ liquidity
+$tx_data=$tx->pm_create_market(
+	$creator,$creator,0/*binary*/,['Yes','No'],'Will X happen by 2026?',
+	300/*oracle_fee bp*/,'0.000 VIZ',100/*creator_fee bp*/,200/*lp_fee bp*/,
+	'100.000 VIZ',0/*lmsr_b, 0 for binary*/,
+	'2026-08-01T00:00:00'/*betting_expiration*/,'2026-08-02T00:00:00'/*result_expiration*/
+);
+$tx_status=$tx->execute($tx_data['json']);
+
+//place an instant bet on side 0 (binary uses outcome_index -1)
+$bet=$tx->pm_place_bet($creator,5/*market_id*/,0/*side*/,-1/*outcome_index*/,'10.000 VIZ');
+$tx->execute($bet['json']);
+```
+
+Optional fields on `pm_oracle_update` accept `null` to leave a field unchanged
+(`insurance_delta` is a signed asset — `"-5.000 VIZ"` to withdraw):
+
+```php
+$upd=$tx->pm_oracle_update('oracle_acc',null/*insurance_delta*/,500/*fee_percent bp*/);
+```
+
+### Commit–reveal betting
+
+`pm_commitment(...)` builds the byte-exact SHA-256 commitment the node re-checks on reveal (a wrong
+preimage forfeits the escrow). `amount`/`min_tokens` are milli-VIZ integers:
+
+```php
+$salt='cafe1234';
+$commitment=$tx->pm_commitment(5/*market_id*/,'alice',0/*side*/,-1/*outcome_index*/,10000/*amount*/,0/*min_tokens*/,$salt);
+//no_reveal_fee_percent MUST equal median(pm_commit_no_reveal_penalty_percent)
+$commit=$tx->pm_commit_bet('alice',5,$commitment,'10.000 VIZ',2000);
+$tx->execute($commit['json']);
+//...later, within the reveal window, re-supply the same values + salt:
+$reveal=$tx->pm_reveal_bet('alice',$commit_id,0,-1,'10.000 VIZ',$salt,0);
+$tx->execute($reveal['json']);
+```
+
+### Read methods (`prediction_market_api`)
+
+Called via `execute_method` like any other API. Pagination is `(...key..., from, limit)` with
+`limit <= 1000`.
+
+```php
+<?php
+include('./class/autoloader.php');
+$api=new VIZ\JsonRPC('https://api.viz.world/');
+
+$market=$api->execute_method('get_market',[5]);
+$active=$api->execute_method('list_markets',[1/*status active*/,0/*from*/,100/*limit*/]);
+$full=$api->execute_method('get_market_full',[5,'alice']);//one-call market detail view
+$props=$api->execute_method('get_pm_chain_properties');//live median governance params
+$kline=$api->execute_method('get_market_kline',[5,0,1000]);//chart series (offset-from-newest)
+```
+
+Full method set: `get_market`, `list_markets`, `list_markets_by_oracle`, `list_markets_by_creator`,
+`get_market_outcomes`, `get_market_weight_sums`, `get_market_bets`, `get_account_positions`,
+`get_market_liquidity`, `get_market_full`, `get_account_leverage_positions`,
+`get_market_leverage_positions`, `get_creator_ban`, `get_leverage_quote`,
+`get_leverage_close_preview`, `get_leverage_convert_preview`, `get_oracle`, `list_oracles`,
+`get_dispute`, `get_dispute_votes`, `get_lazy_pool`, `get_lazy_deposit`, `get_lazy_allocations`,
+`get_market_lazy_allocation`, `get_pm_chain_properties`, `get_market_meta`,
+`list_markets_by_category`, `get_market_categories`, `get_market_kline`.
+
 May VIZ be with you.

--- a/class/VIZ/JsonRPC.php
+++ b/class/VIZ/JsonRPC.php
@@ -127,6 +127,44 @@ class JsonRPC{
 		'lookup_validator_accounts'=>'validator_api',
 		'lookup_witness_accounts'=>'validator_api',
 
+		//prediction_market_api (Onix, HF14)
+		//all PM read methods, limit<=1000, pagination (...key..., from, limit)
+		/* Markets */
+		'get_market'=>'prediction_market_api',
+		'list_markets'=>'prediction_market_api',
+		'list_markets_by_oracle'=>'prediction_market_api',
+		'list_markets_by_creator'=>'prediction_market_api',
+		'get_market_outcomes'=>'prediction_market_api',
+		'get_market_weight_sums'=>'prediction_market_api',
+		'get_market_bets'=>'prediction_market_api',
+		'get_account_positions'=>'prediction_market_api',
+		'get_market_liquidity'=>'prediction_market_api',
+		'get_market_full'=>'prediction_market_api',
+		/* Leverage */
+		'get_account_leverage_positions'=>'prediction_market_api',
+		'get_market_leverage_positions'=>'prediction_market_api',
+		'get_creator_ban'=>'prediction_market_api',
+		'get_leverage_quote'=>'prediction_market_api',
+		'get_leverage_close_preview'=>'prediction_market_api',
+		'get_leverage_convert_preview'=>'prediction_market_api',
+		/* Oracles */
+		'get_oracle'=>'prediction_market_api',
+		'list_oracles'=>'prediction_market_api',
+		/* Disputes */
+		'get_dispute'=>'prediction_market_api',
+		'get_dispute_votes'=>'prediction_market_api',
+		/* Lazy pool & chain properties */
+		'get_lazy_pool'=>'prediction_market_api',
+		'get_lazy_deposit'=>'prediction_market_api',
+		'get_lazy_allocations'=>'prediction_market_api',
+		'get_market_lazy_allocation'=>'prediction_market_api',
+		'get_pm_chain_properties'=>'prediction_market_api',
+		/* Metadata & charts */
+		'get_market_meta'=>'prediction_market_api',
+		'list_markets_by_category'=>'prediction_market_api',
+		'get_market_categories'=>'prediction_market_api',
+		'get_market_kline'=>'prediction_market_api',
+
 		//block_info
 		//https://github.com/VIZ-Blockchain/viz-cpp-node/blob/master/plugins/block_info/block_info_plugin.cpp
 		'get_block_info'=>'block_info',

--- a/class/VIZ/JsonRPC.php
+++ b/class/VIZ/JsonRPC.php
@@ -68,7 +68,6 @@ class JsonRPC{
 		'get_escrow'=>'database_api',
 		'get_expiring_vesting_delegations'=>'database_api',
 		'get_master_history'=>'database_api',
-		'get_owner_history'=>'database_api',
 		'get_recovery_request'=>'database_api',
 		'get_subaccounts_on_sale'=>'database_api',
 		'get_vesting_delegations'=>'database_api',
@@ -77,7 +76,6 @@ class JsonRPC{
 		'lookup_accounts'=>'database_api',
 		/* Authority / validation */
 		'get_potential_signatures'=>'database_api',
-		'get_proposed_transaction'=>'database_api',
 		'get_proposed_transactions'=>'database_api',
 		'get_required_signatures'=>'database_api',
 		'get_transaction_hex'=>'database_api',

--- a/class/VIZ/Transaction.php
+++ b/class/VIZ/Transaction.php
@@ -1397,6 +1397,456 @@ class Transaction{
 		return [$json,$raw];
 	}
 
+	// ===== Prediction Markets (Onix, HF14) — 23 user operations =====
+	// Each op ends with an empty extensions vector (raw '00'; the key is omitted from JSON like the
+	// core ops above). Percent fields are basis points (10000=100%) unless the field note says otherwise;
+	// the pm_leverage_* / conversion knobs are plain percent but are governance params, not op fields.
+	// Object ids (market_id/bet_id/liquidity_id/position_id/commit_id) are bare integers (pm_object_id_type).
+	function build_pm_oracle_register($owner,$insurance,$fee_percent,$fixed_fee,$rules_url,$auto_accept_creator='',$auto_accept_resolver='',$auto_accept=false){
+		$json='["pm_oracle_register",{';
+		$json.='"owner":'.$this->json_string($owner);
+		$json.=',"insurance":"'.$insurance.'"';
+		$json.=',"fee_percent":'.$fee_percent;
+		$json.=',"fixed_fee":"'.$fixed_fee.'"';
+		$json.=',"rules_url":'.$this->json_string($rules_url);
+		$json.=',"auto_accept_creator":'.$this->json_string($auto_accept_creator);
+		$json.=',"auto_accept_resolver":'.$this->json_string($auto_accept_resolver);
+		$json.=',"auto_accept":'.($auto_accept?'true':'false');
+		$json.='}]';
+		$raw='42';//op-id 66
+		$raw.=$this->encode_string($owner);
+		$raw.=$this->encode_asset($insurance);
+		$raw.=$this->encode_uint16($fee_percent);
+		$raw.=$this->encode_asset($fixed_fee);
+		$raw.=$this->encode_string($rules_url);
+		$raw.=$this->encode_string($auto_accept_creator);
+		$raw.=$this->encode_string($auto_accept_resolver);
+		$raw.=$this->encode_bool($auto_accept);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_oracle_update($owner,$insurance_delta=null,$fee_percent=null,$fixed_fee=null,$rules_url=null,$auto_accept_creator=null,$auto_accept_resolver=null,$auto_accept=null){
+		//optional fields: pass null to leave unchanged. insurance_delta is a signed asset ("-5.000 VIZ" to withdraw).
+		$json='["pm_oracle_update",{';
+		$json.='"owner":'.$this->json_string($owner);
+		if($insurance_delta!==null){$json.=',"insurance_delta":"'.$insurance_delta.'"';}
+		if($fee_percent!==null){$json.=',"fee_percent":'.$fee_percent;}
+		if($fixed_fee!==null){$json.=',"fixed_fee":"'.$fixed_fee.'"';}
+		if($rules_url!==null){$json.=',"rules_url":'.$this->json_string($rules_url);}
+		if($auto_accept_creator!==null){$json.=',"auto_accept_creator":'.$this->json_string($auto_accept_creator);}
+		if($auto_accept_resolver!==null){$json.=',"auto_accept_resolver":'.$this->json_string($auto_accept_resolver);}
+		if($auto_accept!==null){$json.=',"auto_accept":'.($auto_accept?'true':'false');}
+		$json.='}]';
+		$raw='43';//op-id 67
+		$raw.=$this->encode_string($owner);
+		$raw.=$this->encode_optional($insurance_delta!==null,$insurance_delta!==null?$this->encode_asset($insurance_delta):'');
+		$raw.=$this->encode_optional($fee_percent!==null,$fee_percent!==null?$this->encode_uint16($fee_percent):'');
+		$raw.=$this->encode_optional($fixed_fee!==null,$fixed_fee!==null?$this->encode_asset($fixed_fee):'');
+		$raw.=$this->encode_optional($rules_url!==null,$rules_url!==null?$this->encode_string($rules_url):'');
+		$raw.=$this->encode_optional($auto_accept_creator!==null,$auto_accept_creator!==null?$this->encode_string($auto_accept_creator):'');
+		$raw.=$this->encode_optional($auto_accept_resolver!==null,$auto_accept_resolver!==null?$this->encode_string($auto_accept_resolver):'');
+		$raw.=$this->encode_optional($auto_accept!==null,$auto_accept!==null?$this->encode_bool($auto_accept):'');
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_create_market($creator,$oracle,$market_type,$outcomes,$url,$oracle_fee_percent,$oracle_fixed_fee,$creator_fee_percent,$liquidity_fee_percent,$liquidity,$lmsr_b,$betting_expiration,$result_expiration,$time_penalty_type=0,$time_penalty_value=0,$penalty_curve_type=0,$allow_early_resolution=false,$allow_cancellation=false,$allow_batch=false,$allow_instant_bet=true,$endogeneity_tier=1,$dispute_mode=0,$dispute_resolver='',$dispute_penalty_percent=0,$metadata=''){
+		$outcomes=array_values($outcomes);
+		$json='["pm_create_market",{';
+		$json.='"creator":'.$this->json_string($creator);
+		$json.=',"oracle":'.$this->json_string($oracle);
+		$json.=',"market_type":'.$market_type;
+		$json.=',"outcomes":'.json_encode($outcomes,JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
+		$json.=',"url":'.$this->json_string($url);
+		$json.=',"oracle_fee_percent":'.$oracle_fee_percent;
+		$json.=',"oracle_fixed_fee":"'.$oracle_fixed_fee.'"';
+		$json.=',"creator_fee_percent":'.$creator_fee_percent;
+		$json.=',"liquidity_fee_percent":'.$liquidity_fee_percent;
+		$json.=',"liquidity":"'.$liquidity.'"';
+		$json.=',"lmsr_b":'.$lmsr_b;
+		$json.=',"betting_expiration":"'.$betting_expiration.'"';
+		$json.=',"result_expiration":"'.$result_expiration.'"';
+		$json.=',"time_penalty_type":'.$time_penalty_type;
+		$json.=',"time_penalty_value":'.$time_penalty_value;
+		$json.=',"penalty_curve_type":'.$penalty_curve_type;
+		$json.=',"allow_early_resolution":'.($allow_early_resolution?'true':'false');
+		$json.=',"allow_cancellation":'.($allow_cancellation?'true':'false');
+		$json.=',"allow_batch":'.($allow_batch?'true':'false');
+		$json.=',"allow_instant_bet":'.($allow_instant_bet?'true':'false');
+		$json.=',"endogeneity_tier":'.$endogeneity_tier;
+		$json.=',"dispute_mode":'.$dispute_mode;
+		$json.=',"dispute_resolver":'.$this->json_string($dispute_resolver);
+		$json.=',"dispute_penalty_percent":'.$dispute_penalty_percent;
+		$json.=',"metadata":'.$this->json_string($metadata);
+		$json.='}]';
+		$raw='44';//op-id 68
+		$raw.=$this->encode_string($creator);
+		$raw.=$this->encode_string($oracle);
+		$raw.=$this->encode_uint8($market_type);
+		$raw.=$this->encode_array($outcomes,['string']);
+		$raw.=$this->encode_string($url);
+		$raw.=$this->encode_uint16($oracle_fee_percent);
+		$raw.=$this->encode_asset($oracle_fixed_fee);
+		$raw.=$this->encode_uint16($creator_fee_percent);
+		$raw.=$this->encode_uint16($liquidity_fee_percent);
+		$raw.=$this->encode_asset($liquidity);
+		$raw.=$this->encode_int64($lmsr_b);
+		$raw.=$this->encode_timestamp($betting_expiration);
+		$raw.=$this->encode_timestamp($result_expiration);
+		$raw.=$this->encode_uint8($time_penalty_type);
+		$raw.=$this->encode_uint32($time_penalty_value);
+		$raw.=$this->encode_uint8($penalty_curve_type);
+		$raw.=$this->encode_bool($allow_early_resolution);
+		$raw.=$this->encode_bool($allow_cancellation);
+		$raw.=$this->encode_bool($allow_batch);
+		$raw.=$this->encode_bool($allow_instant_bet);
+		$raw.=$this->encode_uint8($endogeneity_tier);
+		$raw.=$this->encode_uint8($dispute_mode);
+		$raw.=$this->encode_string($dispute_resolver);
+		$raw.=$this->encode_int16($dispute_penalty_percent);
+		$raw.=$this->encode_string($metadata);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_oracle_accept_market($oracle,$market_id,$accept,$oracle_fee_percent=0,$oracle_fixed_fee='0.000 VIZ'){
+		$json='["pm_oracle_accept_market",{';
+		$json.='"oracle":'.$this->json_string($oracle);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"accept":'.($accept?'true':'false');
+		$json.=',"oracle_fee_percent":'.$oracle_fee_percent;
+		$json.=',"oracle_fixed_fee":"'.$oracle_fixed_fee.'"';
+		$json.='}]';
+		$raw='45';//op-id 69
+		$raw.=$this->encode_string($oracle);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_bool($accept);
+		$raw.=$this->encode_uint16($oracle_fee_percent);
+		$raw.=$this->encode_asset($oracle_fixed_fee);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_place_bet($account,$market_id,$side,$outcome_index,$amount,$min_tokens=0,$mode=0){
+		//binary: side 0/1, outcome_index -1. multi: side -1, outcome_index 0..N-1. mode 0 instant / 1 batch.
+		$json='["pm_place_bet",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"side":'.$side;
+		$json.=',"outcome_index":'.$outcome_index;
+		$json.=',"amount":"'.$amount.'"';
+		$json.=',"min_tokens":'.$min_tokens;
+		$json.=',"mode":'.$mode;
+		$json.='}]';
+		$raw='46';//op-id 70
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_int8($side);
+		$raw.=$this->encode_int16($outcome_index);
+		$raw.=$this->encode_asset($amount);
+		$raw.=$this->encode_int64($min_tokens);
+		$raw.=$this->encode_uint8($mode);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_commit_bet($account,$market_id,$commitment,$escrow_amount,$no_reveal_fee_percent){
+		//commitment = SHA-256 hex of the preimage (see pm_commitment()). no_reveal_fee_percent MUST equal
+		//median(pm_commit_no_reveal_penalty_percent) or the node rejects the commit.
+		$json='["pm_commit_bet",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"commitment":"'.strtolower($commitment).'"';
+		$json.=',"escrow_amount":"'.$escrow_amount.'"';
+		$json.=',"no_reveal_fee_percent":'.$no_reveal_fee_percent;
+		$json.='}]';
+		$raw='47';//op-id 71
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_sha256($commitment);
+		$raw.=$this->encode_asset($escrow_amount);
+		$raw.=$this->encode_uint16($no_reveal_fee_percent);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_reveal_bet($account,$commit_id,$side,$outcome_index,$amount,$salt,$min_tokens=0){
+		$json='["pm_reveal_bet",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"commit_id":'.$commit_id;
+		$json.=',"side":'.$side;
+		$json.=',"outcome_index":'.$outcome_index;
+		$json.=',"amount":"'.$amount.'"';
+		$json.=',"salt":'.$this->json_string($salt);
+		$json.=',"min_tokens":'.$min_tokens;
+		$json.='}]';
+		$raw='48';//op-id 72
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($commit_id);
+		$raw.=$this->encode_int8($side);
+		$raw.=$this->encode_int16($outcome_index);
+		$raw.=$this->encode_asset($amount);
+		$raw.=$this->encode_string($salt);
+		$raw.=$this->encode_int64($min_tokens);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_cancel_bet($account,$bet_id,$min_return=0){
+		$json='["pm_cancel_bet",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"bet_id":'.$bet_id;
+		$json.=',"min_return":'.$min_return;
+		$json.='}]';
+		$raw='49';//op-id 73
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($bet_id);
+		$raw.=$this->encode_int64($min_return);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_add_liquidity($provider,$market_id,$amount){
+		$json='["pm_add_liquidity",{';
+		$json.='"provider":'.$this->json_string($provider);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"amount":"'.$amount.'"';
+		$json.='}]';
+		$raw='4a';//op-id 74
+		$raw.=$this->encode_string($provider);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_asset($amount);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_withdraw_liquidity($provider,$liquidity_id,$amount='0.000 VIZ'){
+		//amount 0 = full position
+		$json='["pm_withdraw_liquidity",{';
+		$json.='"provider":'.$this->json_string($provider);
+		$json.=',"liquidity_id":'.$liquidity_id;
+		$json.=',"amount":"'.$amount.'"';
+		$json.='}]';
+		$raw='4b';//op-id 75
+		$raw.=$this->encode_string($provider);
+		$raw.=$this->encode_int64($liquidity_id);
+		$raw.=$this->encode_asset($amount);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_resolve_market($oracle,$market_id,$winning_outcome,$decision_url='',$decision_reason=''){
+		$json='["pm_resolve_market",{';
+		$json.='"oracle":'.$this->json_string($oracle);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"winning_outcome":'.$winning_outcome;
+		$json.=',"decision_url":'.$this->json_string($decision_url);
+		$json.=',"decision_reason":'.$this->json_string($decision_reason);
+		$json.='}]';
+		$raw='4c';//op-id 76
+		$raw.=$this->encode_string($oracle);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_int16($winning_outcome);
+		$raw.=$this->encode_string($decision_url);
+		$raw.=$this->encode_string($decision_reason);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_no_contest($oracle,$market_id,$reason=''){
+		$json='["pm_no_contest",{';
+		$json.='"oracle":'.$this->json_string($oracle);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"reason":'.$this->json_string($reason);
+		$json.='}]';
+		$raw='4d';//op-id 77
+		$raw.=$this->encode_string($oracle);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_string($reason);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_dispute_create($disputer,$market_id,$proposed_outcome,$reason=''){
+		//proposed_outcome -1 = void/no-contest challenge
+		$json='["pm_dispute_create",{';
+		$json.='"disputer":'.$this->json_string($disputer);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"proposed_outcome":'.$proposed_outcome;
+		$json.=',"reason":'.$this->json_string($reason);
+		$json.='}]';
+		$raw='4e';//op-id 78
+		$raw.=$this->encode_string($disputer);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_int16($proposed_outcome);
+		$raw.=$this->encode_string($reason);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_dispute_vote($voter,$market_id,$vote_outcome,$vote_percent){
+		//committee mode; signed with REGULAR authority. vote_outcome -1 = uphold oracle.
+		$json='["pm_dispute_vote",{';
+		$json.='"voter":'.$this->json_string($voter);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"vote_outcome":'.$vote_outcome;
+		$json.=',"vote_percent":'.$vote_percent;
+		$json.='}]';
+		$raw='4f';//op-id 79
+		$raw.=$this->encode_string($voter);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_int16($vote_outcome);
+		$raw.=$this->encode_int16($vote_percent);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_dispute_resolve($resolver,$market_id,$correct_outcome,$penalty_amount='0.000 VIZ',$ban_oracle=false,$ban_oracle_until='1970-01-01T00:00:00',$ban_creator=false,$ban_creator_until='1970-01-01T00:00:00'){
+		//account mode verdict. *_until = 2106-02-07T06:28:15 for a permanent ban (time_point_sec::maximum()).
+		$json='["pm_dispute_resolve",{';
+		$json.='"resolver":'.$this->json_string($resolver);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"correct_outcome":'.$correct_outcome;
+		$json.=',"penalty_amount":"'.$penalty_amount.'"';
+		$json.=',"ban_oracle":'.($ban_oracle?'true':'false');
+		$json.=',"ban_oracle_until":"'.$ban_oracle_until.'"';
+		$json.=',"ban_creator":'.($ban_creator?'true':'false');
+		$json.=',"ban_creator_until":"'.$ban_creator_until.'"';
+		$json.='}]';
+		$raw='50';//op-id 80
+		$raw.=$this->encode_string($resolver);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_int16($correct_outcome);
+		$raw.=$this->encode_asset($penalty_amount);
+		$raw.=$this->encode_bool($ban_oracle);
+		$raw.=$this->encode_timestamp($ban_oracle_until);
+		$raw.=$this->encode_bool($ban_creator);
+		$raw.=$this->encode_timestamp($ban_creator_until);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_transfer_position($from,$bet_id,$to,$amount=0,$memo=''){
+		//amount = weight to reassign (share_type); 0 = full. memo plaintext or #-prefixed ECIES.
+		$json='["pm_transfer_position",{';
+		$json.='"from":'.$this->json_string($from);
+		$json.=',"bet_id":'.$bet_id;
+		$json.=',"to":'.$this->json_string($to);
+		$json.=',"amount":'.$amount;
+		$json.=',"memo":'.$this->json_string($memo);
+		$json.='}]';
+		$raw='51';//op-id 81
+		$raw.=$this->encode_string($from);
+		$raw.=$this->encode_int64($bet_id);
+		$raw.=$this->encode_string($to);
+		$raw.=$this->encode_int64($amount);
+		$raw.=$this->encode_string($memo);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_lazy_deposit($account,$amount){
+		$json='["pm_lazy_deposit",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"amount":"'.$amount.'"';
+		$json.='}]';
+		$raw='52';//op-id 82
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_asset($amount);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_lazy_withdraw($account,$shares=0,$emergency=false){
+		//shares = pool shares to burn; 0 = all. emergency = withdraw before lock ends (penalty on profit).
+		$json='["pm_lazy_withdraw",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"shares":'.$shares;
+		$json.=',"emergency":'.($emergency?'true':'false');
+		$json.='}]';
+		$raw='53';//op-id 83
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($shares);
+		$raw.=$this->encode_bool($emergency);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_leverage_open($account,$market_id,$outcome_index,$collateral,$loan,$min_tokens=0,$max_slippage_percent=0){
+		//binary CPMM only; gated by pm_leverage_enabled. max_slippage_percent is bp.
+		$json='["pm_leverage_open",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"outcome_index":'.$outcome_index;
+		$json.=',"collateral":"'.$collateral.'"';
+		$json.=',"loan":"'.$loan.'"';
+		$json.=',"min_tokens":'.$min_tokens;
+		$json.=',"max_slippage_percent":'.$max_slippage_percent;
+		$json.='}]';
+		$raw='5b';//op-id 91
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_int16($outcome_index);
+		$raw.=$this->encode_asset($collateral);
+		$raw.=$this->encode_asset($loan);
+		$raw.=$this->encode_int64($min_tokens);
+		$raw.=$this->encode_uint16($max_slippage_percent);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_leverage_close($account,$position_id,$min_return=0){
+		$json='["pm_leverage_close",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"position_id":'.$position_id;
+		$json.=',"min_return":'.$min_return;
+		$json.='}]';
+		$raw='5c';//op-id 92
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($position_id);
+		$raw.=$this->encode_int64($min_return);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_leverage_convert($account,$position_id,$conversion_profit_cost){
+		//conversion_profit_cost MUST equal median(pm_conversion_profit_cost_percent) (plain percent, 50=50%).
+		$json='["pm_leverage_convert",{';
+		$json.='"account":'.$this->json_string($account);
+		$json.=',"position_id":'.$position_id;
+		$json.=',"conversion_profit_cost":'.$conversion_profit_cost;
+		$json.='}]';
+		$raw='5d';//op-id 93
+		$raw.=$this->encode_string($account);
+		$raw.=$this->encode_int64($position_id);
+		$raw.=$this->encode_uint16($conversion_profit_cost);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_dispute_oracle_respond($oracle,$market_id,$response){
+		$json='["pm_dispute_oracle_respond",{';
+		$json.='"oracle":'.$this->json_string($oracle);
+		$json.=',"market_id":'.$market_id;
+		$json.=',"response":'.$this->json_string($response);
+		$json.='}]';
+		$raw='62';//op-id 98
+		$raw.=$this->encode_string($oracle);
+		$raw.=$this->encode_int64($market_id);
+		$raw.=$this->encode_string($response);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function build_pm_unban($resolver,$target,$unban_oracle=false,$unban_creator=false){
+		//resolver must equal the target's banned_by. At least one of unban_oracle/unban_creator must be true.
+		$json='["pm_unban",{';
+		$json.='"resolver":'.$this->json_string($resolver);
+		$json.=',"target":'.$this->json_string($target);
+		$json.=',"unban_oracle":'.($unban_oracle?'true':'false');
+		$json.=',"unban_creator":'.($unban_creator?'true':'false');
+		$json.='}]';
+		$raw='63';//op-id 99
+		$raw.=$this->encode_string($resolver);
+		$raw.=$this->encode_string($target);
+		$raw.=$this->encode_bool($unban_oracle);
+		$raw.=$this->encode_bool($unban_creator);
+		$raw.='00';//extensions
+		return [$json,$raw];
+	}
+	function pm_commitment($market_id,$account,$side,$outcome_index,$amount,$min_tokens,$salt){
+		//SHA-256 commitment for pm_commit_bet (spec 3.6.1). amount & min_tokens are share_type (milli-VIZ,
+		//i.e. VIZ*1000). Raw binary concat, little-endian ints, 32-byte zero-padded account, then salt bytes.
+		$preimage ='';
+		$preimage.=pack('P',$market_id);//8 bytes int64 LE
+		$preimage.=str_pad(substr($account,0,32),32,"\0",STR_PAD_RIGHT);//32-byte account buffer
+		$preimage.=chr($side & 0xFF);//1 byte int8 (multi: -1 => 0xFF)
+		$preimage.=pack('v',$outcome_index & 0xFFFF);//2 bytes int16 LE (binary: -1 => 0xFFFF)
+		$preimage.=pack('P',$amount);//8 bytes int64 LE (milli-VIZ)
+		$preimage.=pack('P',$min_tokens);//8 bytes int64 LE
+		$preimage.=$salt;//raw bytes, no terminator
+		return hash('sha256',$preimage);
+	}
+
 	function start_queue(){
 		$this->queue=true;
 	}
@@ -1465,6 +1915,32 @@ class Transaction{
 	}
 	function encode_uint64($input){
 		return bin2hex(pack('Q',$input));
+	}
+	function encode_int8($input){
+		return bin2hex(pack('c',$input));//signed byte, -1 => ff
+	}
+	function encode_int64($input){
+		//little-endian 8-byte integer (share_type / pm_object_id_type). Values are non-negative in PM ops.
+		return bin2hex(pack('P',$input));
+	}
+	function encode_sha256($input){
+		//raw 32-byte digest, no length prefix. Accepts 64-char hex string.
+		$hex=strtolower($input);
+		if(0===strpos($hex,'0x')){
+			$hex=substr($hex,2);
+		}
+		return str_pad($hex,64,'0',STR_PAD_LEFT);
+	}
+	function encode_optional($present,$hex=''){
+		//fc::optional<T>: 0x00 when absent, 0x01 + encoded value when present
+		if($present){
+			return '01'.$hex;
+		}
+		return '00';
+	}
+	function json_string($input){
+		//robust JSON string literal (handles quotes/unicode); node re-decodes to the same UTF-8 bytes
+		return json_encode((string)$input,JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
 	}
 	function encode_int($input,$bytes){
 		$result='';


### PR DESCRIPTION
## Summary

Adds full client support for the HF14 (Onix) Prediction Markets protocol to the PHP library, per the `prediction-market-library-integration-spec`.

### Operations (`class/VIZ/Transaction.php`)
- All **23 signed PM operations** (`build_pm_*`, op-ids 66–83, 91–93, 98–99), each emitting name-based JSON `["pm_...", {...}]` plus byte-exact binary with the correct varint op-id tag, declared field order, and empty `extensions` terminator.
- `pm_commitment()` helper computing the byte-exact SHA-256 commit-reveal commitment (spec §3.6.1) — verified against the spec golden test vector.
- New binary codecs: `encode_int8`, `encode_int64` (LE), `encode_sha256`, `encode_optional` (fc `optional<T>`), `json_string`.

### API (`class/VIZ/JsonRPC.php`)
- All **29 `prediction_market_api` read methods** registered and callable via `execute_method()` (markets, leverage, oracles, disputes, lazy pool, `get_pm_chain_properties`, metadata/charts).

### Docs
- `README.md`: new Prediction Markets section (builders, commit-reveal flow, read methods).
- `.qoder/docs/operations-status.md`: PM operations + virtual (decode-only) ops + `prediction_market_api` coverage; totals updated to 66 ops / 108 API methods.
- `.qoder/docs/spec/`: HF14 integration spec + full JSON-RPC API spec.

### Notes
- Percent scale handled per field (basis points vs. plain percent); assets are VIZ strings, `share_type` args are raw milli-VIZ integers.
- Read-side surfaces PM governance params via `get_pm_chain_properties`; the write-side `versioned_chain_properties_update` was intentionally **not** extended (that wire layout is out of scope of this spec).

### Verification
- `php -l` clean on edited files.
- All 23 builders smoke-tested: correct op-ids, valid JSON, extensions terminator.
- Commit-reveal `pm_commitment()` matches the spec golden vector exactly.