### PR TITLE
Fix versioned_chain_properties (v5/HF14): add missing pm_leverage_funding_rate_ppm_per_day

### DIFF
--- a/class/VIZ/Transaction.php
+++ b/class/VIZ/Transaction.php
@@ -1140,6 +1140,7 @@ class Transaction{
 				'pm_leverage_max_position_ratio_percent'=>5,
 				'pm_leverage_expiration_buffer_sec'=>86400,
 				'pm_leverage_m_factor_percent'=>50,
+				'pm_leverage_funding_rate_ppm_per_day'=>50,
 				'pm_conversion_profit_cost_percent'=>50,
 				'pm_closed_market_retention_sec'=>432000,
 			]);
@@ -1188,6 +1189,7 @@ class Transaction{
 				'pm_leverage_max_position_ratio_percent'=>'uint16',
 				'pm_leverage_expiration_buffer_sec'=>'uint32',
 				'pm_leverage_m_factor_percent'=>'uint16',
+				'pm_leverage_funding_rate_ppm_per_day'=>'uint32',
 				'pm_conversion_profit_cost_percent'=>'uint16',
 				'pm_closed_market_retention_sec'=>'uint32',
 			]);


### PR DESCRIPTION
## Problem
The `chain_properties_pm` variant (v5, HF14) serializer in `build_versioned_chain_properties_update` omitted `pm_leverage_funding_rate_ppm_per_day` (uint32) — 46 of 47 pm fields. The field was documented (prior commit) but never added to the serializer arrays, so bytes after `pm_leverage_m_factor_percent` shifted and any v5 `versioned_chain_properties_update` would mis-serialize (signature/deserialization mismatch on the node).

## Fix
Added the field (uint32, default 50 = 0.005%/day) to both `$default_props` and `$props_types`, between `pm_leverage_m_factor_percent` and `pm_conversion_profit_cost_percent`, matching the C++ `FC_REFLECT_DERIVED(chain_properties_pm)` order.

## Verification
Byte-verified offline against the C++ struct: the v5 leverage tail now serializes as `3200 32000000 3200 80970600` (m_factor u16=50 | funding u32=50 | conversion u16=50 | retention u32=432000). Order + types identical to the node struct (47/47).

Note: the same field is missing from vendored `viz.min.js` bundles (viz-js-lib source is correct); those need a separate re-vendor.